### PR TITLE
Load env vars lazily for Supabase client

### DIFF
--- a/supabase_client.py
+++ b/supabase_client.py
@@ -3,18 +3,20 @@ import os
 import logging
 from supabase import create_client, Client
 
-# Cargar variables de entorno
-load_dotenv()
-
-SUPABASE_URL = os.getenv('SUPABASE_URL')
-SUPABASE_SERVICE_ROLE_KEY = os.getenv('SUPABASE_SERVICE_ROLE_KEY')
 
 def get_supabase_client() -> Client:
     """Crea y devuelve un cliente de Supabase."""
-    if not SUPABASE_URL or not SUPABASE_SERVICE_ROLE_KEY:
+    # Recargar las variables de entorno en cada llamada para permitir su
+    # configuración durante las pruebas.
+    load_dotenv()
+    supabase_url = os.getenv("SUPABASE_URL")
+    service_role_key = os.getenv("SUPABASE_SERVICE_ROLE_KEY")
+
+    if not supabase_url or not service_role_key:
         raise ValueError("Supabase URL and Service Role Key are required.")
+
     try:
-        return create_client(SUPABASE_URL, SUPABASE_SERVICE_ROLE_KEY)
+        return create_client(supabase_url, service_role_key)
     except Exception as e:
         raise Exception(f"Error creating Supabase client: {str(e)}")
 

--- a/tests/test_supabase_client.py
+++ b/tests/test_supabase_client.py
@@ -3,10 +3,14 @@ from unittest.mock import patch, MagicMock
 import supabase_client
 
 @patch('supabase_client.create_client')
-def test_get_supabase_client(mock_create_client):
+def test_get_supabase_client(mock_create_client, monkeypatch):
     """Test that get_supabase_client calls create_client with the correct credentials."""
+    monkeypatch.setenv('SUPABASE_URL', 'test_url')
+    monkeypatch.setenv('SUPABASE_SERVICE_ROLE_KEY', 'test_key')
+
     supabase_client.get_supabase_client()
-    mock_create_client.assert_called_once_with(supabase_client.SUPABASE_URL, supabase_client.SUPABASE_SERVICE_ROLE_KEY)
+
+    mock_create_client.assert_called_once_with('test_url', 'test_key')
 
 @patch('supabase_client.get_supabase_client')
 def test_get_existing_cities_success(mock_get_supabase_client):


### PR DESCRIPTION
## Summary
- Load Supabase credentials from environment each call instead of at import
- Adjust tests to set fake Supabase credentials with monkeypatch

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68976814751c8332985d0b04125f0ce2