### PR TITLE
Story: restore pipeline runtime observability

### DIFF
--- a/.github/workflows/air-quality-workflow.yml
+++ b/.github/workflows/air-quality-workflow.yml
@@ -1,6 +1,7 @@
 name: Air Quality Pipeline
 
 on:
+  pull_request:
   schedule:
     - cron: '0 * * * *'
   workflow_dispatch:
@@ -15,8 +16,9 @@ on:
           - 'true'
 
 jobs:
-  build:
+  test:
     runs-on: windows-latest
+    if: github.event_name == 'pull_request'
     steps:
       - uses: actions/checkout@v4
       - name: Set up Python
@@ -28,6 +30,26 @@ jobs:
           python -m pip install --upgrade pip
           pip install -r requirements.txt
       - name: Run tests
+        env:
+          SKIP_PIPELINE_DELAYS: '1'
+        run: pytest
+
+  build:
+    runs-on: windows-latest
+    if: github.event_name != 'pull_request'
+    steps:
+      - uses: actions/checkout@v4
+      - name: Set up Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: '3.11'
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r requirements.txt
+      - name: Run tests
+        env:
+          SKIP_PIPELINE_DELAYS: '1'
         run: pytest
       - name: Configure environment variables
         env:

--- a/.github/workflows/air-quality-workflow.yml
+++ b/.github/workflows/air-quality-workflow.yml
@@ -1,8 +1,18 @@
 name: Air Quality Pipeline
+
 on:
   schedule:
-    - cron: '0 */3 * * *'
+    - cron: '0 * * * *'
   workflow_dispatch:
+    inputs:
+      force_update:
+        description: 'Force city updates regardless of last_successful_update_at'
+        required: false
+        default: 'false'
+        type: choice
+        options:
+          - 'false'
+          - 'true'
 
 jobs:
   build:
@@ -20,10 +30,29 @@ jobs:
       - name: Run tests
         run: pytest
       - name: Configure environment variables
+        env:
+          AIRVISUAL_API_KEY: ${{ secrets.AIRVISUAL_API_KEY }}
+          SUPABASE_URL: ${{ secrets.SUPABASE_URL }}
+          SUPABASE_SERVICE_ROLE_KEY: ${{ secrets.SUPABASE_SERVICE_ROLE_KEY }}
         run: |
-          echo AIRVISUAL_API_KEY=${{ secrets.AIRVISUAL_API_KEY }} > .env
-          echo SUPABASE_URL=${{ secrets.SUPABASE_URL }} >> .env
-          echo SUPABASE_SERVICE_ROLE_KEY=${{ secrets.SUPABASE_SERVICE_ROLE_KEY }} >> .env
+          echo AIRVISUAL_API_KEY=${AIRVISUAL_API_KEY} > .env
+          echo SUPABASE_URL=${SUPABASE_URL} >> .env
+          echo SUPABASE_SERVICE_ROLE_KEY=${SUPABASE_SERVICE_ROLE_KEY} >> .env
       - name: Run main.py
+        env:
+          AIRVISUAL_API_KEY: ${{ secrets.AIRVISUAL_API_KEY }}
+          SUPABASE_URL: ${{ secrets.SUPABASE_URL }}
+          SUPABASE_SERVICE_ROLE_KEY: ${{ secrets.SUPABASE_SERVICE_ROLE_KEY }}
         run: |
-          python main.py --force-update
+          if [ "${{ github.event.inputs.force_update }}" = "true" ]; then
+            python main.py --force-update | tee pipeline.log
+          else
+            python main.py | tee pipeline.log
+          fi
+        shell: bash
+      - name: Upload pipeline log
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: pipeline-log
+          path: pipeline.log

--- a/docs/pipeline-runtime-operations.md
+++ b/docs/pipeline-runtime-operations.md
@@ -1,0 +1,59 @@
+# Pipeline Runtime Operations
+
+## Runtime
+
+Workflow: `.github/workflows/air-quality-workflow.yml`
+
+Triggers:
+
+- Scheduled hourly: `0 * * * *`
+- Manual: `workflow_dispatch`
+- Pull request: tests only
+
+## Manual recovery
+
+When data is stale, run the workflow manually with `force_update=true`.
+
+This bypasses the timestamp interval check and attempts to refresh all active cities.
+
+## Healthy run criteria
+
+A run is healthy when:
+
+- at least one update was attempted and at least one reading was inserted, or
+- no updates were needed and at least one active city was skipped as up-to-date.
+
+A run is unhealthy when:
+
+- there are no active cities,
+- any city update fails,
+- updates were attempted but zero readings were inserted, or
+- no active city was updated or skipped.
+
+## Summary block
+
+`main.py` emits a final `[SUMMARY] Pipeline operacional` block with:
+
+- active cities
+- updates attempted
+- readings inserted
+- skipped cities
+- failed updates
+- fetch errors
+- validation failures
+- insert errors
+- update errors
+- per-city results
+
+## Common stale-data causes
+
+- GitHub disabled the scheduled workflow after repository inactivity.
+- A required GitHub Actions secret is missing or stale.
+- AirVisual returned errors or rate limits.
+- Supabase insert or update failed.
+
+## Post-run checks
+
+After a manual recovery run, check the latest reading timestamp in Supabase and review each city status.
+
+The frontend only consumes the data. Pipeline health must be validated from this repo and Supabase.

--- a/main.py
+++ b/main.py
@@ -1,82 +1,224 @@
-import sys
-import os
 import logging
+import os
+import sys
+import time
+from copy import deepcopy
 from dotenv import load_dotenv
-from airvisual_api import fetch_cities, fetch_air_quality_data
+
+from airvisual_api import fetch_air_quality_data, fetch_cities
 from supabase_client import get_existing_cities
 from sync_cities import sync_cities
-from utils import check_if_update_needed, setup_logging
 from update_city import update_city
+from utils import check_if_update_needed, compute_inter_city_delay, delay, setup_logging
 
-# Configurar logging
 setup_logging()
-
 load_dotenv()
 
-SUPABASE_URL = os.getenv('SUPABASE_URL')
-SUPABASE_SERVICE_ROLE_KEY = os.getenv('SUPABASE_SERVICE_ROLE_KEY')
-AIRVISUAL_API_KEY = os.getenv('AIRVISUAL_API_KEY')
+REQUIRED_ENV_VARS = (
+    "SUPABASE_URL",
+    "SUPABASE_SERVICE_ROLE_KEY",
+    "AIRVISUAL_API_KEY",
+)
 
-if not all([SUPABASE_URL, SUPABASE_SERVICE_ROLE_KEY, AIRVISUAL_API_KEY]):
-    raise EnvironmentError("❌ Variables de entorno faltantes. Verifica tu archivo .env o los secretos en GitHub Actions.")
+
+class PipelineRunError(RuntimeError):
+    """Raised when the pipeline completed with an unhealthy operational result."""
 
 
-# Función para obtener las ciudades activas
+def get_required_env() -> dict[str, str]:
+    missing = [env_name for env_name in REQUIRED_ENV_VARS if not os.getenv(env_name)]
+
+    if missing:
+        missing_list = ", ".join(missing)
+        raise EnvironmentError(
+            "Variables de entorno faltantes. "
+            f"Configura estos secretos en GitHub Actions: {missing_list}."
+        )
+
+    return {env_name: os.environ[env_name] for env_name in REQUIRED_ENV_VARS}
+
+
 def get_active_cities(db_cities_list):
-    return [
-        city for city in db_cities_list if city['is_active']
-    ]
+    return [city for city in db_cities_list if city.get("is_active")]
 
-def main(force_update=False):
-    try:
-        # Paso 1: Obtener las ciudades desde la API de AirVisual
-        api_cities = fetch_cities(AIRVISUAL_API_KEY)
 
-        # Paso 2: Obtener las ciudades desde Supabase
-        db_cities = get_existing_cities()
+def build_summary(force_update: bool) -> dict:
+    return {
+        "force_update": force_update,
+        "active_cities": 0,
+        "updates_attempted": 0,
+        "readings_inserted": 0,
+        "skipped_up_to_date": 0,
+        "failed_updates": 0,
+        "fetch_errors": 0,
+        "validation_failures": 0,
+        "insert_errors": 0,
+        "update_errors": 0,
+        "city_results": [],
+        "sync_summary": None,
+    }
 
-        # Paso 3: Sincronizar los datos
-        summary, updated_db_cities_list = sync_cities(api_cities, db_cities)
 
-        # Paso 4: Obtener las ciudades activas de la lista actualizada
-        active_cities = get_active_cities(updated_db_cities_list)
+def record_city_result(summary: dict, city: dict, result: dict) -> None:
+    summary["city_results"].append(
+        {
+            "city_id": city.get("id"),
+            "api_name": city.get("api_name"),
+            **result,
+        }
+    )
 
-        # Paso 5: Verificar si alguna ciudad necesita actualización
-        for city in active_cities:
-            result = check_if_update_needed(city, force_update)
-            
-            if result["needsUpdate"]:
-                logging.info(f"🌬️ Ciudad {city['api_name']} necesita actualización.")
 
-                # ✅ Paso 5.1: Obtener los datos en tiempo real desde la API
-                fetch_result = fetch_air_quality_data(
-                    api_name=city['api_name'],
-                    city_id=city['id'],
-                    state="Nuevo Leon",
-                    country="Mexico",
-                    AIRVISUAL_API_KEY=AIRVISUAL_API_KEY
-                )
-                fetch_result['city_id'] = city['id']  # Agregamos el ID local
+def log_pipeline_summary(summary: dict) -> None:
+    safe_summary = deepcopy(summary)
+    logging.info("\n[SUMMARY] Pipeline operacional")
+    logging.info("Force update: %s", safe_summary["force_update"])
+    logging.info("Ciudades activas: %s", safe_summary["active_cities"])
+    logging.info("Updates intentados: %s", safe_summary["updates_attempted"])
+    logging.info("Lecturas insertadas: %s", safe_summary["readings_inserted"])
+    logging.info("Ciudades sin actualizar por intervalo: %s", safe_summary["skipped_up_to_date"])
+    logging.info("Updates fallidos: %s", safe_summary["failed_updates"])
+    logging.info("Errores de fetch: %s", safe_summary["fetch_errors"])
+    logging.info("Fallos de validacion: %s", safe_summary["validation_failures"])
+    logging.info("Errores de insert: %s", safe_summary["insert_errors"])
+    logging.info("Errores de update status: %s", safe_summary["update_errors"])
 
-                # ✅ Paso 5.2: Preparar e insertar/actualizar en Supabase
-                update_result = update_city(
-                    fetch_or_skip_result=fetch_result
-                )
+    if safe_summary.get("sync_summary") is not None:
+        logging.info("Sync summary: %s", safe_summary["sync_summary"])
 
-                logging.info(f"✅ Update realizado para {city['api_name']}: {update_result}")
+    for city_result in safe_summary["city_results"]:
+        logging.info("City result: %s", city_result)
+
+
+def assert_healthy_summary(summary: dict) -> None:
+    if summary["active_cities"] == 0:
+        raise PipelineRunError("No hay ciudades activas para actualizar.")
+
+    if summary["failed_updates"] > 0:
+        raise PipelineRunError(
+            "El pipeline tuvo updates fallidos. "
+            f"failed_updates={summary['failed_updates']}, "
+            f"readings_inserted={summary['readings_inserted']}."
+        )
+
+    if summary["updates_attempted"] > 0 and summary["readings_inserted"] == 0:
+        raise PipelineRunError(
+            "El pipeline intento actualizar ciudades pero no inserto ninguna lectura."
+        )
+
+    if summary["updates_attempted"] == 0 and summary["skipped_up_to_date"] == 0:
+        raise PipelineRunError("El pipeline no intento ni omitio ninguna ciudad activa.")
+
+
+def main(force_update=False) -> dict:
+    env = get_required_env()
+    summary = build_summary(force_update=force_update)
+
+    api_cities = fetch_cities(env["AIRVISUAL_API_KEY"])
+    db_cities = get_existing_cities()
+    sync_summary, updated_db_cities_list = sync_cities(api_cities, db_cities)
+    summary["sync_summary"] = sync_summary
+
+    active_cities = get_active_cities(updated_db_cities_list)
+    summary["active_cities"] = len(active_cities)
+
+    consecutive_failures = 0
+
+    for city in active_cities:
+        city_started_at = time.perf_counter()
+        check_result = check_if_update_needed(city, force_update)
+
+        if check_result["needsUpdate"]:
+            logging.info("[UPDATE] Ciudad %s necesita actualizacion.", city["api_name"])
+            summary["updates_attempted"] += 1
+
+            fetch_result = fetch_air_quality_data(
+                api_name=city["api_name"],
+                city_id=city["id"],
+                state="Nuevo Leon",
+                country="Mexico",
+                AIRVISUAL_API_KEY=env["AIRVISUAL_API_KEY"],
+            )
+            fetch_result["city_id"] = city["id"]
+
+            update_result = update_city(fetch_or_skip_result=fetch_result)
+            successful_insert = (
+                fetch_result.get("status") == "success"
+                and update_result.get("readingInserted")
+                and not update_result.get("insertError")
+                and not update_result.get("updateError")
+                and not update_result.get("validationErrors")
+            )
+
+            if successful_insert:
+                consecutive_failures = 0
+                summary["readings_inserted"] += 1
+                logging.info("[OK] Update realizado para %s: %s", city["api_name"], update_result)
             else:
-                logging.info(f"⏭️ Ciudad {city['api_name']} no necesita actualización.")
+                consecutive_failures += 1
+                summary["failed_updates"] += 1
 
-        # Paso 6: Mostrar las ciudades activas
-        logging.info("\n📍 Ciudades activas:")
-        for city in active_cities:
-            logging.info(f"ID: {city['id']}, Nombre: {city['api_name']}, Última actualización exitosa: {city['last_successful_update_at']}, Estado: {city['last_update_status']}")
+                if fetch_result.get("status") == "error":
+                    summary["fetch_errors"] += 1
+                if update_result.get("validationErrors"):
+                    summary["validation_failures"] += 1
+                if update_result.get("insertError"):
+                    summary["insert_errors"] += 1
+                if update_result.get("updateError"):
+                    summary["update_errors"] += 1
 
-    except Exception as e:
-        # En caso de que ocurra un error, lo manejamos y seguimos
-        logging.error(f"⚠️ Ocurrió un error: {e}")
-    
+                logging.warning("[WARN] Update con alertas para %s: %s", city["api_name"], update_result)
+
+            record_city_result(
+                summary,
+                city,
+                {
+                    "needed_update": True,
+                    "fetch_status": fetch_result.get("status"),
+                    "reading_inserted": bool(update_result.get("readingInserted")),
+                    "city_status_updated": bool(update_result.get("cityStatusUpdated")),
+                    "insert_error": update_result.get("insertError"),
+                    "update_error": update_result.get("updateError"),
+                    "validation_errors": update_result.get("validationErrors"),
+                },
+            )
+        else:
+            logging.info("[SKIP] Ciudad %s no necesita actualizacion.", city["api_name"])
+            summary["skipped_up_to_date"] += 1
+            consecutive_failures = 0
+            record_city_result(
+                summary,
+                city,
+                {
+                    "needed_update": False,
+                    "reason": check_result.get("errorMessage") or "up_to_date",
+                },
+            )
+
+        inter_city_delay = compute_inter_city_delay(consecutive_failures)
+        elapsed_city = time.perf_counter() - city_started_at
+        logging.info(
+            "[TIMING] Ciudad %s procesada en %.2fs. Esperando %.1fs antes de la "
+            "siguiente (fallos consecutivos: %s).",
+            city["api_name"],
+            elapsed_city,
+            inter_city_delay,
+            consecutive_failures,
+        )
+        delay(inter_city_delay)
+
+    log_pipeline_summary(summary)
+    assert_healthy_summary(summary)
+    return summary
+
+
 if __name__ == "__main__":
-    force_update = "--force-update" in sys.argv
-    main(force_update=force_update)
-    logging.info("\n🚀 Pipeline terminado exitosamente.\n")
+    force_update_enabled = "--force-update" in sys.argv
+
+    try:
+        main(force_update=force_update_enabled)
+    except Exception as error:
+        logging.exception("[FAIL] Pipeline terminado con error operativo: %s", error)
+        sys.exit(1)
+
+    logging.info("\n[DONE] Pipeline terminado exitosamente.\n")

--- a/utils.py
+++ b/utils.py
@@ -96,7 +96,7 @@ def delay(seconds: float):
 
 
 def compute_inter_city_delay(consecutive_failures: int = 0) -> float:
-    """Compute an inter-city delay between 5-12s with exponential backoff and jitter."""
+    """Compute an inter-city delay between 8-15s with exponential backoff and jitter."""
     base = MIN_INTER_CITY_DELAY_SECONDS
     cap = MAX_INTER_CITY_DELAY_SECONDS
     exponent = max(consecutive_failures - 1, 0)


### PR DESCRIPTION
## Summary

Restores operational confidence for the MtyRespira air quality producer pipeline.

### Runtime changes
- `main.py` now returns a structured operational summary.
- Missing required env vars now fail the run before work begins.
- Runtime exceptions now exit with code `1` instead of being swallowed.
- Pipeline now fails when:
  - there are no active cities,
  - a city update fails,
  - updates are attempted but zero readings are inserted,
  - no active city is updated or skipped.
- Final logs include `[SUMMARY] Pipeline operacional` with per-city results and counters.

### Workflow changes
- Keeps hourly schedule: `0 * * * *`.
- Adds manual `workflow_dispatch` input: `force_update=true|false`.
- Pull requests now run safe tests only and do not execute the real pipeline or require secrets.
- Scheduled/manual runs still upload `pipeline.log`.

### Docs
- Adds `docs/pipeline-runtime-operations.md` runbook.

## Supabase note

Attempted to access project `xjekikweaiddfwjjaqbd`, but the current Supabase connector returned `You do not have permission to perform this action`. Once the invitation is accepted in the same connected account, we can validate stale readings and city status directly.

## Testing

- PR workflow should run `pytest` only.
- Manual/scheduled workflow validates runtime with real secrets.