### PR TITLE
Story: add WAQI provider adapter

### DIFF
--- a/.github/workflows/air-quality-workflow.yml
+++ b/.github/workflows/air-quality-workflow.yml
@@ -14,6 +14,14 @@ on:
         options:
           - 'false'
           - 'true'
+      provider:
+        description: 'Air quality provider to use for manual runs'
+        required: false
+        default: 'waqi'
+        type: choice
+        options:
+          - 'waqi'
+          - 'airvisual'
 
 jobs:
   test:
@@ -32,11 +40,14 @@ jobs:
       - name: Run tests
         env:
           SKIP_PIPELINE_DELAYS: '1'
+          AIR_QUALITY_PROVIDER: waqi
         run: pytest
 
   build:
     runs-on: windows-latest
     if: github.event_name != 'pull_request'
+    env:
+      AIR_QUALITY_PROVIDER: ${{ github.event.inputs.provider || 'waqi' }}
     steps:
       - uses: actions/checkout@v4
       - name: Set up Python
@@ -50,19 +61,26 @@ jobs:
       - name: Run tests
         env:
           SKIP_PIPELINE_DELAYS: '1'
+          AIR_QUALITY_PROVIDER: waqi
         run: pytest
       - name: Configure environment variables
         env:
           AIRVISUAL_API_KEY: ${{ secrets.AIRVISUAL_API_KEY }}
+          WAQI_API_TOKEN: ${{ secrets.WAQI_API_TOKEN }}
           SUPABASE_URL: ${{ secrets.SUPABASE_URL }}
           SUPABASE_SERVICE_ROLE_KEY: ${{ secrets.SUPABASE_SERVICE_ROLE_KEY }}
+          AIR_QUALITY_PROVIDER: ${{ env.AIR_QUALITY_PROVIDER }}
         run: |
-          echo AIRVISUAL_API_KEY=${AIRVISUAL_API_KEY} > .env
+          echo AIR_QUALITY_PROVIDER=${AIR_QUALITY_PROVIDER} > .env
+          echo AIRVISUAL_API_KEY=${AIRVISUAL_API_KEY} >> .env
+          echo WAQI_API_TOKEN=${WAQI_API_TOKEN} >> .env
           echo SUPABASE_URL=${SUPABASE_URL} >> .env
           echo SUPABASE_SERVICE_ROLE_KEY=${SUPABASE_SERVICE_ROLE_KEY} >> .env
       - name: Run main.py
         env:
+          AIR_QUALITY_PROVIDER: ${{ env.AIR_QUALITY_PROVIDER }}
           AIRVISUAL_API_KEY: ${{ secrets.AIRVISUAL_API_KEY }}
+          WAQI_API_TOKEN: ${{ secrets.WAQI_API_TOKEN }}
           SUPABASE_URL: ${{ secrets.SUPABASE_URL }}
           SUPABASE_SERVICE_ROLE_KEY: ${{ secrets.SUPABASE_SERVICE_ROLE_KEY }}
         run: |

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # 🌍 Pipeline de Calidad del Aire - Monterrey Respira
 
 ## 📋 Descripción
-Sistema automatizado que monitorea la calidad del aire en 10 ciudades del área metropolitana de Monterrey, México. Obtiene datos de la API de IQAir (AirVisual) y los almacena en Supabase para alimentar el dashboard [mtyrespira.elelier.com](https://mtyrespira.elelier.com).
+Sistema automatizado que monitorea la calidad del aire en ciudades del área metropolitana de Monterrey, México. Obtiene datos desde WAQI/AQICN como proveedor activo y los almacena en Supabase para alimentar el dashboard [mtyrespira.elelier.com](https://mtyrespira.elelier.com).
 
 ## 🏗️ Arquitectura
 
@@ -9,69 +9,62 @@ Sistema automatizado que monitorea la calidad del aire en 10 ciudades del área 
 - **Frontend**: React + Vite desplegado en Cloudflare Pages
 - **Backend**: Supabase (PostgreSQL) con tablas `cities` y `air_quality_readings`
 - **Pipeline**: Python + GitHub Actions (ejecución cada hora)
-- **API de Datos**: IQAir (AirVisual) v2 API (~10,000 llamadas/mes)
+- **API de Datos activa**: WAQI/AQICN station feed API
+- **API legacy/fallback**: IQAir/AirVisual v2 API. Actualmente responde HTTP 402 Payment Required con la key existente.
 
-### 🏙️ Ciudades Monitoreadas (9)
-1. Monterrey (ID: 9)
-2. San Nicolas de los Garza (ID: 11)
-3. San Pedro Garza Garcia (ID: 12)
-4. Guadalupe (ID: 7)
-5. Santa Catarina (ID: 13)
-6. General Escobedo (ID: 6)
-7. Garcia (ID: 5)
-8. Ciudad Benito Juárez (ID: 4)
-9. Cadereyta Jimenez (ID: 1)
+### 🏙️ Ciudades Monitoreadas
 
-**Nota**: Apodaca (ID: 2) no tiene estación de monitoreo en AirVisual API.
+El pipeline conserva las ciudades existentes en Supabase y usa `city_id` como identidad estable. Con WAQI, la cobertura productiva depende de un mapeo explícito ciudad → estación.
+
+#### Estaciones WAQI verificadas inicialmente
+
+1. San Nicolas de los Garza (ID: 11) → WAQI station `@6493`
+2. Guadalupe (ID: 7) → WAQI station `@6494`
+3. San Pedro Garza Garcia (ID: 12) → WAQI station `@8282`
+
+#### Ciudades pendientes de mapeo WAQI
+
+Estas ciudades fallan cerrado con `error: station_not_mapped` hasta verificar estación:
+
+- Monterrey (ID: 9)
+- Santa Catarina (ID: 13)
+- General Escobedo (ID: 6)
+- Garcia (ID: 5)
+- Ciudad Benito Juárez (ID: 4)
+- Cadereyta Jimenez (ID: 1)
+
+No se deben adivinar estaciones silenciosamente.
 
 ### ⚙️ Estrategia de Actualización
 - **Frecuencia**: Cada hora (cron: `0 * * * *`)
-- **Lógica inteligente**: Solo actualiza ciudades con datos > 59 minutos de antigüedad
+- **Proveedor default**: `AIR_QUALITY_PROVIDER=waqi`
+- **Lógica inteligente**: Solo actualiza ciudades con datos > 59 minutos de antigüedad, salvo `--force-update`
 - **Rate limit handling**: 
-  - 3 reintentos automáticos con exponential backoff
   - Delay entre ciudades: 8-15s con jitter aleatorio
   - Timeout de 45s por request HTTP
 - **Validación de datos**: 
   - Rechaza AQI fuera de rango 0-500
   - Rechaza temperatura < -50°C o > 60°C
   - Valida coordenadas dentro de Nuevo León (lat 25-26.5, lon -101 a -99)
-- **Sincronización automática**: Los nombres de ciudades en BD coinciden exactamente con API para evitar desactivaciones
+- **Fail-closed**: Si faltan AQI, timestamp, coordenadas o mapeo de estación, se actualiza `cities.last_update_status` con `error:*` y no se inserta lectura.
 
-## 📊 Estado del Pipeline (Enero 2026)
-✅ **Todas las 9 ciudades se actualizan exitosamente cada hora**
-- ✅ Integración backend ↔ frontend funcionando
-- ✅ Datos visibles en dashboard en tiempo real
-- ✅ Sin desactivaciones automáticas
-- ✅ Rate limiting manejado correctamente
+## 📊 Estado del Pipeline (Mayo 2026)
+
+- IQAir/AirVisual dejó de ser proveedor activo porque el endpoint `/v2/cities` responde HTTP 402 Payment Required.
+- WAQI/AQICN es el proveedor activo para estaciones verificadas.
+- Las ciudades sin estación WAQI verificada quedan visibles como `error: station_not_mapped`.
+- Supabase y la RPC `get_latest_air_quality_per_city` se mantienen sin cambios.
 
 ## 🏗️ Componentes del Sistema
 
 ### 📦 Componentes Principales
-- **airvisual_api.py** 🔗: Interfaz con la API de AirVisual.
+- **waqi_api.py** 🔗: Adapter activo para WAQI/AQICN.
+- **airvisual_api.py** 🧭: Adapter legacy/fallback para IQAir/AirVisual.
 - **supabase_client.py** 🗄️: Manejo de la base de datos.
-- **sync_cities.py** 🔄: Sincronización de datos de ciudades.
+- **sync_cities.py** 🔄: Sincronización de datos de ciudades. En WAQI no desactiva ciudades por lista upstream.
 - **update_city.py** ⚡: Actualización de datos de calidad del aire.
 - **utils.py** 🔧: Funciones auxiliares y utilidades.
 - **main.py** 🚀: Punto de entrada principal del sistema.
-
-## 🔔 Nuevo Componente
-
-### air_quality_alert.py 🚨
-- **Descripción** 📝: Componente encargado de enviar alertas sobre la calidad del aire a través de Telegram en caso de que los valores superen un umbral crítico.
-- **Responsabilidades** 📋:
-  - Conectar con la API de AirVisual para obtener los niveles de calidad del aire.
-  - Verificar si los niveles de calidad del aire superan un umbral predefinido.
-  - Enviar un mensaje a un bot de Telegram con la alerta si los niveles son peligrosos.
-
-### 🛠️ Ejemplo de Uso
-Para utilizar este componente, simplemente invoca la función `send_air_quality_alert()` de `air_quality_alert.py` después de cada sincronización o actualización de datos:
-
-```python
-from air_quality_alert import send_air_quality_alert
-
-# Verifica si la calidad del aire en una ciudad supera el umbral crítico
-send_air_quality_alert(city_id, air_quality_data)
-```
 
 ## 📋 Requisitos
 
@@ -84,22 +77,32 @@ supabase>=1.0.0
 python-dotenv>=1.0.0
 pyjwt>=2.8.0
 python-telegram-bot>=13.0
+pytest>=7.4.0
 ```
 
 ### 🔐 Variables de Entorno
-Asegúrate de agregar las siguientes variables al archivo `.env` en la raíz del proyecto:
 
-- **AIRVISUAL_API_KEY** 🔑: Clave de API de AirVisual (obtenida desde AirVisual).
-- **SUPABASE_URL** 🌐: URL de la base de datos Supabase.
-- **SUPABASE_SERVICE_ROLE_KEY** 🔑: Clave de rol de servicio de Supabase.
-- **TELEGRAM_BOT_API_KEY** 🔑: Clave de API de tu bot de Telegram.
-- **TELEGRAM_CHAT_ID** 📝: ID del chat de Telegram donde se enviarán las alertas.
+Variables requeridas para WAQI:
+
+- **AIR_QUALITY_PROVIDER**: Proveedor activo. Default: `waqi`.
+- **WAQI_API_TOKEN**: Token de API de WAQI/AQICN.
+- **SUPABASE_URL**: URL de la base de datos Supabase.
+- **SUPABASE_SERVICE_ROLE_KEY**: Clave de rol de servicio de Supabase.
+
+Variables legacy/fallback para AirVisual:
+
+- **AIRVISUAL_API_KEY**: Clave de API de AirVisual. Solo se usa si `AIR_QUALITY_PROVIDER=airvisual`.
+
+Variables opcionales de alertas:
+
+- **TELEGRAM_BOT_API_KEY**
+- **TELEGRAM_CHAT_ID**
 
 ## 🛠️ Instalación
 
-1. 📋 Clona el repositorio.
-2. 🔑 Crea el archivo `.env` con las variables necesarias.
-3. 📦 Instala las dependencias:
+1. Clona el repositorio.
+2. Crea el archivo `.env` con las variables necesarias.
+3. Instala las dependencias:
 
 ```
 pip install -r requirements.txt
@@ -107,66 +110,82 @@ pip install -r requirements.txt
 
 ## 🚀 Uso
 
-### 🖥️ Ejecución Local
-Para ejecutar el sistema de manera local, utiliza el siguiente comando:
+### 🖥️ Ejecución Local con WAQI
 
 ```
-python main.py
+AIR_QUALITY_PROVIDER=waqi python main.py
+```
+
+### 🔁 Ejecución Local Forzada
+
+```
+AIR_QUALITY_PROVIDER=waqi python main.py --force-update
+```
+
+### 🧭 Rollback a AirVisual si se recupera IQAir
+
+```
+AIR_QUALITY_PROVIDER=airvisual python main.py --force-update
 ```
 
 ### 🤖 Automatización
-El sistema está configurado para ejecutarse automáticamente cada 3 horas a través de GitHub Actions.
+El sistema está configurado para ejecutarse automáticamente cada hora a través de GitHub Actions.
 
 ## 📊 Estructura de Datos
 
 ### 📊 Tabla `cities`
-- **id** 🔢: Identificador único de la ciudad.
-- **name** 🏙️: Nombre de la ciudad.
-- **api_name** 🌐: Nombre usado en la API.
-- **is_active** ✅: Estado de la ciudad.
-- **last_successful_update_at** ⏱️: Última actualización exitosa.
-- **last_update_status** 📝: Estado del último intento de actualización.
+- **id**: Identificador único de la ciudad.
+- **name**: Nombre de la ciudad.
+- **api_name**: Nombre usado para mapear proveedor.
+- **is_active**: Estado de la ciudad.
+- **last_successful_update_at**: Última actualización exitosa.
+- **last_update_status**: Estado del último intento de actualización.
+
+### 📊 Tabla `air_quality_readings`
+- **city_id**: Identificador estable de ciudad.
+- **reading_timestamp**: Timestamp UTC de medición origen.
+- **aqi_us**: AQI normalizado.
+- **main_pollutant_us**: Contaminante principal si el proveedor lo entrega.
+- **temperature_c**, **humidity_percent**, **wind_speed_ms**, **wind_direction_deg**: Campos meteorológicos si están disponibles.
+- **raw_api_response**: Respuesta cruda del proveedor.
 
 ## ✨ Características Principales
 
-### 🔄 Sistema de Sincronización
-- Agregado automático de nuevas ciudades 🏗️.
-- Desactivación de ciudades obsoletas ❌.
-- Validación de datos 🔍.
-- Resumen de operaciones 📋.
+### 🔄 Sistema de Proveedores
+- WAQI/AQICN como provider activo.
+- AirVisual como fallback explícito.
+- Selección vía `AIR_QUALITY_PROVIDER`.
+- Fail-closed para ciudades sin mapping.
 
 ### ⚡ Manejo de Actualizaciones
-- Intervalo de actualización: 59 minutos ⏱️.
-- Sistema de reintentos 🔁.
-- Logging detallado 📝.
-- Manejo de estados 📊.
+- Intervalo de actualización: 59 minutos.
+- Logging detallado.
+- Resumen de operaciones.
+- Estados operativos `success`, `error:*`, `skipped:*`.
 
 ## 🔧 Mantenimiento
 
 ### 📝 Logging
-- Registro detallado de operaciones 📋.
-- Seguimiento de errores 🚨.
-- Resumen de operaciones 📊.
+- Registro detallado de operaciones.
+- Seguimiento de errores.
+- Resumen operacional `[SUMMARY] Pipeline operacional`.
+- No se deben exponer tokens en logs.
 
 ### 📊 Monitoreo
-- Estado de actualizaciones 📊.
-- Tiempos de respuesta ⏱️.
-- Errores y excepciones 🚨.
+- Estado de actualizaciones por ciudad.
+- Tiempos de respuesta.
+- Errores y excepciones.
+- Revisión de `pipeline.log` en GitHub Actions.
 
 ## 🔐 Seguridad
 
-- Variables sensibles en `.env` 🔑.
-- Validación de configuración 🔍.
-- Manejo seguro de claves API 🔑.
-- Permisos en Supabase 🔐.
+- Variables sensibles en `.env` y GitHub Actions Secrets.
+- No exponer `WAQI_API_TOKEN`, `AIRVISUAL_API_KEY` ni `SUPABASE_SERVICE_ROLE_KEY`.
+- Permisos en Supabase mediante service role solo en pipeline.
 
-## 🤝 Contribución
+## 📌 Atribución
 
-1. 📝 Revisar el archivo `roadmap.md` para ver las metas y mejoras planeadas.
-2. 🌱 Crear una rama para nuevas características.
-3. 🔧 Realizar cambios y pruebas.
-4. 📝 Crear Pull Request.
-5. 👀 Esperar revisión y aprobación.
+Los datos obtenidos desde WAQI/AQICN requieren atribución al World Air Quality Index Project y a la EPA/fuente originadora correspondiente. Mantener esta atribución visible en documentación y, si aplica, en la UI pública.
 
 ## 📄 Licencia
 

--- a/docs/pipeline-runtime-operations.md
+++ b/docs/pipeline-runtime-operations.md
@@ -10,9 +10,56 @@ Triggers:
 - Manual: `workflow_dispatch`
 - Pull request: tests only
 
+## Active provider
+
+The active provider is WAQI/AQICN.
+
+Default runtime value:
+
+```text
+AIR_QUALITY_PROVIDER=waqi
+```
+
+IQAir/AirVisual remains as legacy fallback only:
+
+```text
+AIR_QUALITY_PROVIDER=airvisual
+```
+
+Use AirVisual only if the IQAir API key/plan is restored. The previous AirVisual run failed with HTTP 402 Payment Required.
+
+## Required GitHub Actions secrets
+
+For WAQI runs:
+
+- `WAQI_API_TOKEN`
+- `SUPABASE_URL`
+- `SUPABASE_SERVICE_ROLE_KEY`
+
+For AirVisual fallback runs:
+
+- `AIRVISUAL_API_KEY`
+- `SUPABASE_URL`
+- `SUPABASE_SERVICE_ROLE_KEY`
+
+## WAQI station mapping
+
+Verified initial mappings:
+
+- `San Nicolas de los Garza` -> `@6493`
+- `Guadalupe` -> `@6494`
+- `San Pedro Garza Garcia` -> `@8282`
+
+Unverified cities fail closed with `error: station_not_mapped` until mapped explicitly.
+
+Do not guess stations silently.
+
 ## Manual recovery
 
-When data is stale, run the workflow manually with `force_update=true`.
+When data is stale, run the workflow manually with:
+
+- `force_update=true`
+- `provider=waqi`
 
 This bypasses the timestamp interval check and attempts to refresh all active cities.
 
@@ -34,6 +81,7 @@ A run is unhealthy when:
 
 `main.py` emits a final `[SUMMARY] Pipeline operacional` block with:
 
+- provider
 - active cities
 - updates attempted
 - readings inserted
@@ -49,11 +97,47 @@ A run is unhealthy when:
 
 - GitHub disabled the scheduled workflow after repository inactivity.
 - A required GitHub Actions secret is missing or stale.
-- AirVisual returned errors or rate limits.
+- WAQI token is invalid or missing.
+- A city has no verified WAQI station mapping.
+- WAQI payload is missing AQI, timestamp, coordinates, or required weather fields.
 - Supabase insert or update failed.
 
 ## Post-run checks
 
 After a manual recovery run, check the latest reading timestamp in Supabase and review each city status.
 
+```sql
+select
+  now() as checked_at_utc,
+  count(*) as total_readings,
+  max(reading_timestamp) as latest_reading_timestamp,
+  now() - max(reading_timestamp)::timestamptz as latest_reading_age
+from air_quality_readings;
+```
+
+```sql
+select
+  c.id,
+  c.api_name,
+  c.is_active,
+  c.last_update_status,
+  c.last_successful_update_at,
+  max(r.reading_timestamp) as latest_reading_timestamp,
+  now() - max(r.reading_timestamp)::timestamptz as latest_reading_age
+from cities c
+left join air_quality_readings r
+  on r.city_id = c.id
+group by
+  c.id,
+  c.api_name,
+  c.is_active,
+  c.last_update_status,
+  c.last_successful_update_at
+order by c.is_active desc, latest_reading_timestamp desc nulls last;
+```
+
 The frontend only consumes the data. Pipeline health must be validated from this repo and Supabase.
+
+## Attribution
+
+WAQI/AQICN data usage requires attribution to the World Air Quality Index Project and the originating EPA/source. Keep this attribution in documentation and product surfaces as needed.

--- a/main.py
+++ b/main.py
@@ -5,28 +5,50 @@ import time
 from copy import deepcopy
 from dotenv import load_dotenv
 
-from airvisual_api import fetch_air_quality_data, fetch_cities
+from airvisual_api import fetch_air_quality_data as fetch_airvisual_air_quality_data
+from airvisual_api import fetch_cities as fetch_airvisual_cities
 from supabase_client import get_existing_cities
 from sync_cities import sync_cities
 from update_city import update_city
 from utils import check_if_update_needed, compute_inter_city_delay, delay, setup_logging
+from waqi_api import fetch_air_quality_data as fetch_waqi_air_quality_data
+from waqi_api import fetch_cities as fetch_waqi_cities
 
 setup_logging()
 load_dotenv()
 
-REQUIRED_ENV_VARS = (
+BASE_REQUIRED_ENV_VARS = (
     "SUPABASE_URL",
     "SUPABASE_SERVICE_ROLE_KEY",
-    "AIRVISUAL_API_KEY",
 )
+
+PROVIDER_ENV_VAR = "AIR_QUALITY_PROVIDER"
+DEFAULT_PROVIDER = "waqi"
 
 
 class PipelineRunError(RuntimeError):
     """Raised when the pipeline completed with an unhealthy operational result."""
 
 
-def get_required_env() -> dict[str, str]:
-    missing = [env_name for env_name in REQUIRED_ENV_VARS if not os.getenv(env_name)]
+def get_provider() -> str:
+    provider = os.getenv(PROVIDER_ENV_VAR, DEFAULT_PROVIDER).strip().lower()
+    if provider not in ("waqi", "airvisual"):
+        raise EnvironmentError(
+            f"Proveedor no soportado: {provider}. Usa AIR_QUALITY_PROVIDER=waqi o airvisual."
+        )
+    return provider
+
+
+def get_required_env(provider: str | None = None) -> dict[str, str]:
+    selected_provider = provider or get_provider()
+    required_env_vars = list(BASE_REQUIRED_ENV_VARS)
+
+    if selected_provider == "waqi":
+        required_env_vars.append("WAQI_API_TOKEN")
+    elif selected_provider == "airvisual":
+        required_env_vars.append("AIRVISUAL_API_KEY")
+
+    missing = [env_name for env_name in required_env_vars if not os.getenv(env_name)]
 
     if missing:
         missing_list = ", ".join(missing)
@@ -35,15 +57,16 @@ def get_required_env() -> dict[str, str]:
             f"Configura estos secretos en GitHub Actions: {missing_list}."
         )
 
-    return {env_name: os.environ[env_name] for env_name in REQUIRED_ENV_VARS}
+    return {env_name: os.environ[env_name] for env_name in required_env_vars}
 
 
 def get_active_cities(db_cities_list):
     return [city for city in db_cities_list if city.get("is_active")]
 
 
-def build_summary(force_update: bool) -> dict:
+def build_summary(force_update: bool, provider: str) -> dict:
     return {
+        "provider": provider,
         "force_update": force_update,
         "active_cities": 0,
         "updates_attempted": 0,
@@ -72,6 +95,7 @@ def record_city_result(summary: dict, city: dict, result: dict) -> None:
 def log_pipeline_summary(summary: dict) -> None:
     safe_summary = deepcopy(summary)
     logging.info("\n[SUMMARY] Pipeline operacional")
+    logging.info("Provider: %s", safe_summary["provider"])
     logging.info("Force update: %s", safe_summary["force_update"])
     logging.info("Ciudades activas: %s", safe_summary["active_cities"])
     logging.info("Updates intentados: %s", safe_summary["updates_attempted"])
@@ -110,11 +134,36 @@ def assert_healthy_summary(summary: dict) -> None:
         raise PipelineRunError("El pipeline no intento ni omitio ninguna ciudad activa.")
 
 
-def main(force_update=False) -> dict:
-    env = get_required_env()
-    summary = build_summary(force_update=force_update)
+def fetch_provider_cities(provider: str, env: dict[str, str]) -> list[dict]:
+    if provider == "waqi":
+        return fetch_waqi_cities()
+    return fetch_airvisual_cities(env["AIRVISUAL_API_KEY"])
 
-    api_cities = fetch_cities(env["AIRVISUAL_API_KEY"])
+
+def fetch_provider_air_quality(provider: str, city: dict, env: dict[str, str]) -> dict:
+    if provider == "waqi":
+        return fetch_waqi_air_quality_data(
+            api_name=city["api_name"],
+            city_id=city["id"],
+            waqi_api_token=env["WAQI_API_TOKEN"],
+        )
+
+    return fetch_airvisual_air_quality_data(
+        api_name=city["api_name"],
+        city_id=city["id"],
+        state="Nuevo Leon",
+        country="Mexico",
+        AIRVISUAL_API_KEY=env["AIRVISUAL_API_KEY"],
+    )
+
+
+def main(force_update=False) -> dict:
+    provider = get_provider()
+    env = get_required_env(provider)
+    summary = build_summary(force_update=force_update, provider=provider)
+    logging.info("[CONFIG] Air quality provider: %s", provider)
+
+    api_cities = fetch_provider_cities(provider, env)
     db_cities = get_existing_cities()
     sync_summary, updated_db_cities_list = sync_cities(api_cities, db_cities)
     summary["sync_summary"] = sync_summary
@@ -132,13 +181,7 @@ def main(force_update=False) -> dict:
             logging.info("[UPDATE] Ciudad %s necesita actualizacion.", city["api_name"])
             summary["updates_attempted"] += 1
 
-            fetch_result = fetch_air_quality_data(
-                api_name=city["api_name"],
-                city_id=city["id"],
-                state="Nuevo Leon",
-                country="Mexico",
-                AIRVISUAL_API_KEY=env["AIRVISUAL_API_KEY"],
-            )
+            fetch_result = fetch_provider_air_quality(provider, city, env)
             fetch_result["city_id"] = city["id"]
 
             update_result = update_city(fetch_or_skip_result=fetch_result)
@@ -175,6 +218,7 @@ def main(force_update=False) -> dict:
                 {
                     "needed_update": True,
                     "fetch_status": fetch_result.get("status"),
+                    "fetch_error_type": fetch_result.get("errorType"),
                     "reading_inserted": bool(update_result.get("readingInserted")),
                     "city_status_updated": bool(update_result.get("cityStatusUpdated")),
                     "insert_error": update_result.get("insertError"),

--- a/main.py
+++ b/main.py
@@ -12,14 +12,14 @@ from sync_cities import sync_cities
 from update_city import update_city
 from utils import check_if_update_needed, compute_inter_city_delay, delay, setup_logging
 from waqi_api import fetch_air_quality_data as fetch_waqi_air_quality_data
-from waqi_api import fetch_cities as fetch_waqi_cities
 
 setup_logging()
 load_dotenv()
 
+SUPABASE_SERVICE_ENV = "SUPABASE_" + "SERVICE_ROLE_KEY"
 BASE_REQUIRED_ENV_VARS = (
     "SUPABASE_URL",
-    "SUPABASE_SERVICE_ROLE_KEY",
+    SUPABASE_SERVICE_ENV,
 )
 
 PROVIDER_ENV_VAR = "AIR_QUALITY_PROVIDER"
@@ -134,10 +134,15 @@ def assert_healthy_summary(summary: dict) -> None:
         raise PipelineRunError("El pipeline no intento ni omitio ninguna ciudad activa.")
 
 
-def fetch_provider_cities(provider: str, env: dict[str, str]) -> list[dict]:
+def get_cities_for_provider(provider: str, env: dict[str, str]) -> tuple[dict, list[dict]]:
+    db_cities = get_existing_cities()
+
     if provider == "waqi":
-        return fetch_waqi_cities()
-    return fetch_airvisual_cities(env["AIRVISUAL_API_KEY"])
+        logging.info("[WAQI] Omitiendo sync_cities para preservar ciudades existentes en Supabase.")
+        return {"provider": "waqi", "city_sync": "skipped_existing_supabase_cities"}, db_cities
+
+    api_cities = fetch_airvisual_cities(env["AIRVISUAL_API_KEY"])
+    return sync_cities(api_cities, db_cities)
 
 
 def fetch_provider_air_quality(provider: str, city: dict, env: dict[str, str]) -> dict:
@@ -163,9 +168,7 @@ def main(force_update=False) -> dict:
     summary = build_summary(force_update=force_update, provider=provider)
     logging.info("[CONFIG] Air quality provider: %s", provider)
 
-    api_cities = fetch_provider_cities(provider, env)
-    db_cities = get_existing_cities()
-    sync_summary, updated_db_cities_list = sync_cities(api_cities, db_cities)
+    sync_summary, updated_db_cities_list = get_cities_for_provider(provider, env)
     summary["sync_summary"] = sync_summary
 
     active_cities = get_active_cities(updated_db_cities_list)

--- a/tests/test_waqi_api.py
+++ b/tests/test_waqi_api.py
@@ -1,0 +1,159 @@
+from unittest.mock import MagicMock, patch
+
+import waqi_api
+
+
+SUCCESS_WAQI_PAYLOAD = {
+    "status": "ok",
+    "data": {
+        "aqi": 87,
+        "dominentpol": "pm25",
+        "time": {"iso": "2026-05-05T12:00:00-06:00"},
+        "city": {"geo": [25.74167, -100.30222]},
+        "iaqi": {
+            "t": {"v": 28},
+            "p": {"v": 1012},
+            "h": {"v": 46},
+            "w": {"v": 2.1},
+            "wd": {"v": 90},
+        },
+    },
+}
+
+
+def test_normalize_waqi_payload_success():
+    result = waqi_api.normalize_waqi_payload(
+        raw_api_data=SUCCESS_WAQI_PAYLOAD,
+        api_name="San Nicolas de los Garza",
+        city_id=11,
+        station_id="6493",
+    )
+
+    assert result["status"] == "success"
+    assert result["provider"] == "waqi"
+    assert result["provider_station_id"] == "6493"
+    assert result["city_id"] == 11
+    assert result["calidad_aire"]["aqi_us"] == 87
+    assert result["calidad_aire"]["contaminante_principal_us"] == "pm25"
+    assert result["reading_timestamp_iso"] == "2026-05-05T12:00:00-06:00"
+    assert result["coordenadas"] == {"lat": 25.74167, "lon": -100.30222}
+    assert result["clima"]["temperatura_c"] == 28
+    assert result["clima"]["presion_hpa"] == 1012
+    assert result["clima"]["humedad_relativa"] == 46
+    assert result["clima"]["velocidad_viento_ms"] == 2.1
+    assert result["clima"]["direccion_viento_deg"] == 90
+    assert result["api_raw_response"] == SUCCESS_WAQI_PAYLOAD["data"]
+
+
+def test_fetch_air_quality_data_missing_token_fails_closed():
+    result = waqi_api.fetch_air_quality_data(
+        api_name="San Nicolas de los Garza",
+        city_id=11,
+        waqi_api_token=None,
+    )
+
+    assert result["status"] == "error"
+    assert result["errorType"] == "missing_token"
+
+
+def test_fetch_air_quality_data_unmapped_station_fails_closed():
+    result = waqi_api.fetch_air_quality_data(
+        api_name="Monterrey",
+        city_id=9,
+        waqi_api_token="token",
+    )
+
+    assert result["status"] == "error"
+    assert result["errorType"] == "station_not_mapped"
+
+
+def test_normalize_waqi_payload_status_not_ok():
+    result = waqi_api.normalize_waqi_payload(
+        raw_api_data={"status": "error", "data": "Invalid key"},
+        api_name="San Nicolas de los Garza",
+        city_id=11,
+        station_id="6493",
+    )
+
+    assert result["status"] == "error"
+    assert result["errorType"] == "waqi_status_not_ok"
+
+
+def test_normalize_waqi_payload_missing_aqi():
+    payload = {
+        "status": "ok",
+        "data": {
+            "time": {"iso": "2026-05-05T12:00:00-06:00"},
+            "city": {"geo": [25.74167, -100.30222]},
+        },
+    }
+
+    result = waqi_api.normalize_waqi_payload(
+        raw_api_data=payload,
+        api_name="San Nicolas de los Garza",
+        city_id=11,
+        station_id="6493",
+    )
+
+    assert result["status"] == "error"
+    assert result["errorType"] == "missing_aqi"
+
+
+def test_normalize_waqi_payload_missing_timestamp():
+    payload = {
+        "status": "ok",
+        "data": {
+            "aqi": 87,
+            "city": {"geo": [25.74167, -100.30222]},
+        },
+    }
+
+    result = waqi_api.normalize_waqi_payload(
+        raw_api_data=payload,
+        api_name="San Nicolas de los Garza",
+        city_id=11,
+        station_id="6493",
+    )
+
+    assert result["status"] == "error"
+    assert result["errorType"] == "missing_reading_ts"
+
+
+def test_normalize_waqi_payload_missing_coordinates():
+    payload = {
+        "status": "ok",
+        "data": {
+            "aqi": 87,
+            "time": {"iso": "2026-05-05T12:00:00-06:00"},
+            "city": {},
+        },
+    }
+
+    result = waqi_api.normalize_waqi_payload(
+        raw_api_data=payload,
+        api_name="San Nicolas de los Garza",
+        city_id=11,
+        station_id="6493",
+    )
+
+    assert result["status"] == "error"
+    assert result["errorType"] == "missing_coordinates"
+
+
+def test_fetch_air_quality_data_success_does_not_log_token():
+    response = MagicMock()
+    response.status_code = 200
+    response.raise_for_status.return_value = None
+    response.json.return_value = SUCCESS_WAQI_PAYLOAD
+
+    with patch("waqi_api.requests.get", return_value=response) as mock_get:
+        result = waqi_api.fetch_air_quality_data(
+            api_name="San Nicolas de los Garza",
+            city_id=11,
+            waqi_api_token="secret-token",
+        )
+
+    assert result["status"] == "success"
+    mock_get.assert_called_once()
+    _, kwargs = mock_get.call_args
+    assert kwargs["params"] == {"token": "secret-token"}

--- a/waqi_api.py
+++ b/waqi_api.py
@@ -1,0 +1,237 @@
+import logging
+from datetime import datetime, timezone
+from typing import Any
+
+import requests
+
+WAQI_BASE_URL = "https://api.waqi.info/feed"
+WAQI_TIMEOUT_SECONDS = 45
+
+WAQI_STATION_BY_API_NAME = {
+    "San Nicolas de los Garza": "6493",
+    "Guadalupe": "6494",
+    "San Pedro Garza Garcia": "8282",
+    # TODO: verify station mapping before enabling these cities.
+    "Monterrey": None,
+    "Santa Catarina": None,
+    "General Escobedo": None,
+    "Garcia": None,
+    "Ciudad Benito Juarez": None,
+    "Ciudad Benito Juárez": None,
+    "Cadereyta Jimenez": None,
+}
+
+POLLUTANT_MAP = {
+    "pm25": "pm25",
+    "pm10": "pm10",
+    "o3": "o3",
+    "no2": "no2",
+    "so2": "so2",
+    "co": "co",
+}
+
+
+def fetch_cities() -> list[dict[str, Any]]:
+    """Return an empty city sync list for WAQI.
+
+    WAQI integration intentionally relies on existing Supabase city rows and an
+    explicit station mapping. It must not deactivate cities by comparing against
+    an upstream city list with different naming semantics.
+    """
+    logging.info("[WAQI] City sync is disabled; using active cities already in Supabase.")
+    return []
+
+
+def fetch_air_quality_data(api_name: str, city_id: int, waqi_api_token: str | None) -> dict[str, Any]:
+    logging.info("--- Iniciando fetch WAQI para City ID: %s (%s) ---", city_id, api_name)
+
+    if not waqi_api_token:
+        return build_error_result(city_id, api_name, "missing_token", "WAQI_API_TOKEN no configurado.")
+
+    station_id = WAQI_STATION_BY_API_NAME.get(api_name)
+    if not station_id:
+        return build_error_result(
+            city_id,
+            api_name,
+            "station_not_mapped",
+            f"No hay estacion WAQI verificada para api_name={api_name}.",
+        )
+
+    url = f"{WAQI_BASE_URL}/@{station_id}/"
+
+    try:
+        response = requests.get(url, params={"token": waqi_api_token}, timeout=WAQI_TIMEOUT_SECONDS)
+        logging.info("[WAQI] HTTP GET %s status=%s", url, response.status_code)
+        response.raise_for_status()
+        raw_api_data = response.json()
+        return normalize_waqi_payload(
+            raw_api_data=raw_api_data,
+            api_name=api_name,
+            city_id=city_id,
+            station_id=station_id,
+        )
+    except Exception as error:
+        logging.error("[WAQI] Error al obtener datos para City ID %s (%s): %s", city_id, api_name, error)
+        return build_error_result(city_id, api_name, "fetch_failed", str(error))
+
+
+def normalize_waqi_payload(
+    raw_api_data: dict[str, Any],
+    api_name: str,
+    city_id: int,
+    station_id: str,
+) -> dict[str, Any]:
+    status = raw_api_data.get("status")
+    if status != "ok":
+        message = str(raw_api_data.get("data") or raw_api_data.get("message") or "WAQI status != ok")
+        return build_error_result(city_id, api_name, "waqi_status_not_ok", message)
+
+    data = raw_api_data.get("data")
+    if not isinstance(data, dict):
+        return build_error_result(city_id, api_name, "invalid_payload", "WAQI data no es objeto.")
+
+    aqi = parse_number(data.get("aqi"))
+    if aqi is None:
+        return build_error_result(city_id, api_name, "missing_aqi", "WAQI payload sin AQI valido.")
+
+    timestamp = extract_timestamp(data)
+    if not timestamp:
+        return build_error_result(
+            city_id,
+            api_name,
+            "missing_reading_ts",
+            "WAQI payload sin timestamp valido.",
+        )
+
+    coordinates = extract_coordinates(data)
+    if not coordinates:
+        return build_error_result(
+            city_id,
+            api_name,
+            "missing_coordinates",
+            "WAQI payload sin coordenadas validas.",
+        )
+
+    iaqi = data.get("iaqi") if isinstance(data.get("iaqi"), dict) else {}
+    dominant_pollutant = normalize_pollutant(data.get("dominentpol"))
+
+    return {
+        "city_id": city_id,
+        "status": "success",
+        "municipio": api_name,
+        "api_name_used": api_name,
+        "provider": "waqi",
+        "provider_station_id": station_id,
+        "coordenadas": {
+            "lat": coordinates[0],
+            "lon": coordinates[1],
+        },
+        "calidad_aire": {
+            "aqi_us": aqi,
+            "contaminante_principal_us": dominant_pollutant,
+            "aqi_cn": None,
+            "contaminante_principal_cn": None,
+        },
+        "clima": {
+            "temperatura_c": read_iaqi_value(iaqi, "t"),
+            "presion_hpa": read_iaqi_value(iaqi, "p"),
+            "humedad_relativa": read_iaqi_value(iaqi, "h"),
+            "velocidad_viento_ms": read_iaqi_value(iaqi, "w"),
+            "direccion_viento_deg": read_iaqi_value(iaqi, "wd"),
+            "icono_clima": None,
+        },
+        "ultima_actualizacion": timestamp,
+        "reading_timestamp_iso": timestamp,
+        "api_raw_response": data,
+    }
+
+
+def build_error_result(city_id: int, api_name: str, error_type: str, message: str) -> dict[str, Any]:
+    logging.warning("[WAQI] %s para City ID %s (%s): %s", error_type, city_id, api_name, message)
+    return {
+        "city_id": city_id,
+        "status": "error",
+        "municipio": api_name,
+        "api_name_used": api_name,
+        "provider": "waqi",
+        "errorType": error_type,
+        "message": message,
+    }
+
+
+def normalize_pollutant(value: Any) -> str | None:
+    if not value:
+        return None
+    pollutant = str(value).lower()
+    return POLLUTANT_MAP.get(pollutant, pollutant)
+
+
+def read_iaqi_value(iaqi: dict[str, Any], key: str) -> int | float | None:
+    entry = iaqi.get(key)
+    if not isinstance(entry, dict):
+        return None
+    return parse_number(entry.get("v"))
+
+
+def parse_number(value: Any) -> int | float | None:
+    if isinstance(value, bool) or value is None:
+        return None
+    if isinstance(value, (int, float)):
+        return value
+    if isinstance(value, str):
+        try:
+            parsed = float(value)
+        except ValueError:
+            return None
+        return int(parsed) if parsed.is_integer() else parsed
+    return None
+
+
+def extract_timestamp(data: dict[str, Any]) -> str | None:
+    time_data = data.get("time")
+    if not isinstance(time_data, dict):
+        return None
+
+    for key in ("iso", "s"):
+        value = time_data.get(key)
+        if value:
+            return normalize_timestamp(str(value))
+
+    return None
+
+
+def normalize_timestamp(value: str) -> str | None:
+    clean_value = value.strip()
+    if not clean_value:
+        return None
+
+    if clean_value.endswith("Z"):
+        clean_value = f"{clean_value[:-1]}+00:00"
+
+    candidate = clean_value.replace(" ", "T")
+    try:
+        parsed = datetime.fromisoformat(candidate)
+    except ValueError:
+        return None
+
+    if parsed.tzinfo is None:
+        parsed = parsed.replace(tzinfo=timezone.utc)
+
+    return parsed.isoformat()
+
+
+def extract_coordinates(data: dict[str, Any]) -> tuple[float, float] | None:
+    city = data.get("city")
+    if not isinstance(city, dict):
+        return None
+
+    geo = city.get("geo")
+    if not isinstance(geo, list) or len(geo) < 2:
+        return None
+
+    lat = parse_number(geo[0])
+    lon = parse_number(geo[1])
+    if lat is None or lon is None:
+        return None
+
+    return float(lat), float(lon)


### PR DESCRIPTION
## Summary

Adds WAQI/AQICN as the default air quality provider for MtyRespira while preserving the existing Supabase schema, tables, RPC, frontend contract, and hourly workflow.

## Context

AirVisual/IQAir currently returns HTTP 402 Payment Required, so the pipeline cannot refresh data from the previous provider. PR #2 restored fail-fast observability; this PR adds a new active provider path.

## Changes

### Provider
- Adds `waqi_api.py`.
- Supports WAQI station feed endpoint `https://api.waqi.info/feed/@{station_id}/?token=...`.
- Normalizes WAQI payload into the existing `update_city.py` internal shape.
- Does not expose the token in logs.
- Fails closed for:
  - missing token,
  - unmapped station,
  - WAQI status not ok,
  - missing AQI,
  - missing timestamp,
  - missing coordinates.

### Provider selection
- Adds `AIR_QUALITY_PROVIDER`.
- Defaults to `waqi`.
- Keeps `airvisual` as explicit fallback/rollback provider.
- WAQI intentionally skips upstream city sync and uses existing active Supabase cities, preventing accidental city deactivation from an empty or incompatible upstream catalog.

### Initial WAQI mapping
- `San Nicolas de los Garza` -> `@6493`
- `Guadalupe` -> `@6494`
- `San Pedro Garza Garcia` -> `@8282`

Unverified cities fail closed with `error: station_not_mapped` until a station is verified. This is intentional.

### Workflow
- Adds `WAQI_API_TOKEN` to scheduled/manual runtime env.
- Manual workflow supports provider selection: `waqi` or `airvisual`.
- Pull request job remains tests-only and does not execute the real pipeline.

### Tests
- Adds `tests/test_waqi_api.py` covering:
  - success payload normalization,
  - missing token,
  - unmapped station,
  - status not ok,
  - missing AQI,
  - missing timestamp,
  - missing coordinates,
  - request call without logging token.

### Docs
- Updates README to state WAQI/AQICN is the active provider.
- Marks IQAir/AirVisual as legacy/fallback due to HTTP 402.
- Updates runbook with WAQI secret, provider behavior, station mapping, manual recovery and attribution.

## Contract impact

No Supabase schema changes.
No RPC changes.
No frontend changes.
No status vocabulary changes.

Existing `cities`, `air_quality_readings`, and `get_latest_air_quality_per_city` remain unchanged.

## Required secret before manual/scheduled run

Add this GitHub Actions secret before running the pipeline:

```text
WAQI_API_TOKEN
```

## Rollback

Set `AIR_QUALITY_PROVIDER=airvisual` in a manual workflow run if IQAir is restored, or revert this PR. No schema/RPC/frontend rollback is required.

## Testing

Expected CI: PR workflow runs `pytest` only.