### PR TITLE
Restore MtyRespira fresh data after WAQI rollout

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ El pipeline conserva las ciudades existentes en Supabase y usa `city_id` como id
 | Ciudad Benito Juarez | Verificada por página pública AQICN + validación runtime | `@8113` | Juarez, Nuevo León / Cloud API H8113. |
 | Cadereyta Jimenez | Verificada por página pública AQICN + validación runtime | `@10950` | Cadereyta, Monterrey, Nuevo León / Cloud API H10950. |
 
-Las estaciones quedan sujetas a validación runtime antes de insertar: `status=ok`, AQI, timestamp y coordenadas dentro de Nuevo León. Si WAQI devuelve payload inválido o fuera de rango, el pipeline falla cerrado y no inserta lectura.
+Las estaciones quedan sujetas a validación runtime antes de insertar: `status=ok`, AQI, timestamp y coordenadas dentro de Nuevo León. Si WAQI devuelve payload inválido o fuera de rango, el pipeline falla cerrado y no inserta lectura. Los campos meteorológicos son secundarios: si WAQI entrega temperatura, se valida rango; si faltan temperatura, humedad, viento o presión, la lectura puede insertarse con esos campos nulos.
 
 #### Criterio para habilitar o cambiar una estación WAQI
 
@@ -52,8 +52,9 @@ Si cualquier punto queda dudoso, mantener o regresar el mapping a `None` + TODO 
   - Delay entre ciudades: 8-15s con jitter aleatorio
   - Timeout de 45s por request HTTP
 - **Validación de datos**: 
-  - Rechaza AQI fuera de rango 0-500
-  - Rechaza temperatura < -50°C o > 60°C
+  - Rechaza AQI faltante, no numérico o fuera de rango 0-500
+  - Rechaza temperatura fuera de rango < -50°C o > 60°C cuando WAQI la entrega
+  - Permite campos meteorológicos nulos cuando el proveedor no los entrega
   - Valida coordenadas dentro de Nuevo León (lat 25-26.5, lon -101 a -99)
 - **Fail-closed**: Si faltan AQI, timestamp, coordenadas o mapeo de estación, se actualiza `cities.last_update_status` con `error:*` y no se inserta lectura.
 

--- a/docs/pipeline-runtime-operations.md
+++ b/docs/pipeline-runtime-operations.md
@@ -60,6 +60,8 @@ The expected active municipality coverage is defined in `waqi_api.EXPECTED_ACTIV
 
 Mappings are explicit, but every runtime fetch still fails closed before insert if WAQI does not return `status=ok`, AQI, timestamp, and coordinates inside Nuevo Leon.
 
+Weather fields are secondary. WAQI can omit `iaqi.t`, pressure, humidity, wind, or weather icon. Missing weather fields must be persisted as null instead of blocking an otherwise valid AQI reading. If temperature is present, range validation still applies.
+
 Do not guess stations silently.
 
 ## Station verification criteria
@@ -94,8 +96,9 @@ A run is unhealthy when:
 
 - there are no active cities,
 - any fatal city update fails,
-- updates were attempted but zero readings were inserted, or
-- no active city was updated or skipped.
+- updates were attempted but zero readings were inserted,
+- no active city was updated or skipped,
+- AQI, timestamp, or coordinates are missing/invalid for all attempted cities.
 
 `station_not_mapped` is non-fatal only when at least one mapped city inserts a reading or all healthy mapped cities are up-to-date.
 
@@ -124,9 +127,22 @@ For WAQI, each fetch also logs the mapped station as `@station_id` or `unmapped`
 - A required GitHub Actions secret is missing or stale.
 - WAQI token is invalid or missing.
 - A city has no verified WAQI station mapping.
-- WAQI payload is missing AQI, timestamp, coordinates, or required weather fields.
+- WAQI payload is missing AQI, timestamp, or coordinates.
 - WAQI station coordinates are outside Nuevo León.
 - Supabase insert or update failed.
+- Frontend reads a valid RPC response but rejects or hides rows because of stale-data thresholds or cache.
+
+## Incident note: public data missing after WAQI coverage rollout
+
+Observed risk after the complete WAQI coverage rollout: the WAQI adapter correctly treats weather fields as optional, but shared payload validation still required `temperature_c`. If WAQI returned valid AQI, timestamp, and Nuevo León coordinates without `iaqi.t`, the pipeline rejected the reading with `validation_failed`, inserted nothing, and the public frontend had no fresh data to show.
+
+Recovery rule:
+
+- Keep AQI, timestamp, and coordinates mandatory.
+- Keep temperature range validation when temperature is present.
+- Allow null weather fields to flow into nullable `air_quality_readings` columns.
+- Run manual recovery with `force_update=true`, `provider=waqi`.
+- Verify SQL freshness and `get_latest_air_quality_per_city` after the run.
 
 ## Post-run checks
 
@@ -160,6 +176,10 @@ group by
   c.last_update_status,
   c.last_successful_update_at
 order by c.is_active desc, latest_reading_timestamp desc nulls last;
+```
+
+```sql
+select * from public.get_latest_air_quality_per_city();
 ```
 
 The frontend only consumes the data. Pipeline health must be validated from this repo and Supabase.

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -70,6 +70,31 @@ def test_validate_reading_payload_success():
     assert result['valid'] is True
 
 
+def test_validate_reading_payload_allows_missing_weather_fields():
+    reading = {
+        'calidad_aire': {'aqi_us': 75},
+        'clima': {
+            'temperatura_c': None,
+            'humedad_relativa': None,
+            'velocidad_viento_ms': None,
+        },
+        'coordenadas': {'lat': 25.5, 'lon': -99.5}
+    }
+    result = validate_reading_payload(reading)
+    assert result['valid'] is True
+
+
+def test_validate_reading_payload_rejects_invalid_temperature_when_present():
+    reading = {
+        'calidad_aire': {'aqi_us': 75},
+        'clima': {'temperatura_c': 'unknown'},
+        'coordenadas': {'lat': 25.5, 'lon': -99.5}
+    }
+    result = validate_reading_payload(reading)
+    assert result['valid'] is False
+    assert 'invalid_temperature' in result['reasons']
+
+
 def test_validate_reading_payload_failure():
     reading = {
         'calidad_aire': {'aqi_us': 800},

--- a/utils.py
+++ b/utils.py
@@ -106,9 +106,10 @@ def compute_inter_city_delay(consecutive_failures: int = 0) -> float:
 
 
 def validate_reading_payload(reading: dict) -> dict:
-    """Validate pollution/weather payload ranges and coordinates.
+    """Validate required reading fields and optional weather ranges.
 
-    Returns {"valid": bool, "reasons": list[str]}.
+    AQI and coordinates remain mandatory. Weather fields from WAQI can be
+    partial or null; when temperature is present, its range is still guarded.
     """
     reasons = []
     if not isinstance(reading, dict):
@@ -125,10 +126,11 @@ def validate_reading_payload(reading: dict) -> dict:
     elif aqi_us < 0 or aqi_us > 500:
         reasons.append("aqi_us_out_of_range")
 
-    if temperature_c is None or not isinstance(temperature_c, (int, float)):
-        reasons.append("missing_or_invalid_temperature")
-    elif temperature_c < -50 or temperature_c > 60:
-        reasons.append("temperature_out_of_range")
+    if temperature_c is not None:
+        if not isinstance(temperature_c, (int, float)):
+            reasons.append("invalid_temperature")
+        elif temperature_c < -50 or temperature_c > 60:
+            reasons.append("temperature_out_of_range")
 
     if lat is None or lon is None:
         reasons.append("missing_coordinates")


### PR DESCRIPTION
## Summary

Incident fix for stale/missing public MtyRespira data after the WAQI station coverage rollout.

Root-cause hypothesis from code/runtime contract review:
- PR #5 made WAQI the active provider and normalizes weather fields as optional/null when WAQI omits them.
- `utils.validate_reading_payload` still required `clima.temperatura_c` for every successful insert.
- WAQI can return valid AQI + timestamp + Nuevo León coordinates without `iaqi.t`.
- In that case, `update_city.py` marks the city as `error: validation_failed`, inserts no row, and the frontend/RPC has no fresh reading to show.

Change:
- Keep fail-closed validation for required fields: AQI, timestamp upstream via WAQI normalizer, and coordinates inside Nuevo León.
- Allow optional weather fields to be null.
- Still validate temperature range/type when temperature is present.
- Add tests for missing weather fields and invalid present temperature.
- Update runtime docs/playbook with the recovery rule and post-run SQL checks.

## Contract / safety

No changes to:
- Supabase schema
- `cities`
- `air_quality_readings`
- RPC `get_latest_air_quality_per_city`
- frontend repo
- workflow trigger model
- secret names

This preserves the shared contract: weather columns are nullable; AQI + timestamp + coordinates remain the integrity boundary.

## Validation

Expected CI:
- PR workflow runs `pytest` only.

Local/tooling limitation:
- I could not execute Supabase SQL against project `xjekikweaiddfwjjaqbd` from this session: the Supabase connector returned `You do not have permission to perform this action`; project also was not listed in accessible Supabase projects. No DB mutation was attempted.
- `fetch_commit_workflow_runs` for merge commit `8f0f9cb` returned no runs, likely because the workflow has PR-only tests and scheduled/manual runtime jobs are not PR-triggered for that commit.

## Post-merge manual recovery

Run workflow manually:

- `force_update=true`
- `provider=waqi`

Then validate in Supabase:

```sql
select now(), count(*), max(reading_timestamp), now()-max(reading_timestamp)::timestamptz from public.air_quality_readings;
```

```sql
select c.id,c.api_name,c.is_active,c.last_update_status,c.last_successful_update_at,max(r.reading_timestamp) latest
from cities c
left join air_quality_readings r on r.city_id=c.id
group by c.id
order by c.is_active desc, latest desc nulls last;
```

```sql
select * from public.get_latest_air_quality_per_city();
```

Finally validate `https://mtyrespira.elelier.com/` with hard refresh/incognito.

## Rollback

Revert this PR to restore the previous stricter validation. Operationally, that may reintroduce stale public data if WAQI omits temperature.