### PR TITLE
Add Supabase URL preflight for pipeline incidents

### DIFF
--- a/docs/pipeline-runtime-operations.md
+++ b/docs/pipeline-runtime-operations.md
@@ -42,6 +42,14 @@ For AirVisual fallback runs:
 - `SUPABASE_URL`
 - `SUPABASE_SERVICE_ROLE_KEY`
 
+`SUPABASE_URL` must be the public API URL:
+
+```text
+https://<project-ref>.supabase.co
+```
+
+Do not use the Postgres host (`db.<project-ref>.supabase.co`), Studio URL, project dashboard URL, or any old project URL.
+
 ## WAQI station mapping
 
 The expected active municipality coverage is defined in `waqi_api.EXPECTED_ACTIVE_API_NAMES` and guarded by tests. WAQI sync does not deactivate cities.
@@ -125,6 +133,7 @@ For WAQI, each fetch also logs the mapped station as `@station_id` or `unmapped`
 
 - GitHub disabled the scheduled workflow after repository inactivity.
 - A required GitHub Actions secret is missing or stale.
+- `SUPABASE_URL` points to a wrong, old, or DNS-unresolvable Supabase host.
 - WAQI token is invalid or missing.
 - A city has no verified WAQI station mapping.
 - WAQI payload is missing AQI, timestamp, or coordinates.
@@ -143,6 +152,24 @@ Recovery rule:
 - Allow null weather fields to flow into nullable `air_quality_readings` columns.
 - Run manual recovery with `force_update=true`, `provider=waqi`.
 - Verify SQL freshness and `get_latest_air_quality_per_city` after the run.
+
+## Incident note: Supabase DNS/connectivity failure
+
+If the run fails before WAQI fetch with an error like:
+
+```text
+Failed to get existing cities from Supabase: [Errno 11001] getaddrinfo failed
+```
+
+then the pipeline cannot resolve the Supabase API host from `SUPABASE_URL`.
+
+Recovery rule:
+
+- Check GitHub Actions secret `SUPABASE_URL`.
+- It must be `https://<project-ref>.supabase.co`.
+- Confirm the project is active in Supabase.
+- Confirm the same project hosts `cities`, `air_quality_readings`, and `get_latest_air_quality_per_city`.
+- Re-run manual recovery after correcting the secret.
 
 ## Post-run checks
 

--- a/supabase_client.py
+++ b/supabase_client.py
@@ -8,6 +8,7 @@ from urllib.parse import urlparse
 from supabase import Client, create_client
 
 EXPECTED_SUPABASE_DOMAIN_SUFFIX = ".supabase.co"
+NON_API_SUPABASE_HOST_PREFIXES = ("db.",)
 
 
 def get_safe_supabase_url_host(supabase_url: str) -> str:
@@ -18,6 +19,14 @@ def get_safe_supabase_url_host(supabase_url: str) -> str:
     """
     parsed = urlparse(supabase_url)
     return parsed.hostname or "unparseable-host"
+
+
+def build_invalid_supabase_api_url_error(host: str) -> ValueError:
+    return ValueError(
+        "SUPABASE_URL no parece una API URL de Supabase. "
+        "Usa https://<project-ref>.supabase.co, no el host de Postgres ni otro endpoint. "
+        f"Host detectado: {host}."
+    )
 
 
 def validate_supabase_url(supabase_url: str) -> None:
@@ -33,11 +42,10 @@ def validate_supabase_url(supabase_url: str) -> None:
         )
 
     if not host.endswith(EXPECTED_SUPABASE_DOMAIN_SUFFIX):
-        raise ValueError(
-            "SUPABASE_URL no parece una API URL de Supabase. "
-            "Usa https://<project-ref>.supabase.co, no el host de Postgres ni otro endpoint. "
-            f"Host detectado: {host}."
-        )
+        raise build_invalid_supabase_api_url_error(host)
+
+    if host.startswith(NON_API_SUPABASE_HOST_PREFIXES):
+        raise build_invalid_supabase_api_url_error(host)
 
     try:
         socket.getaddrinfo(host, 443)

--- a/supabase_client.py
+++ b/supabase_client.py
@@ -1,8 +1,51 @@
 from datetime import datetime
 from dotenv import load_dotenv
-import os
 import logging
-from supabase import create_client, Client
+import os
+import socket
+from urllib.parse import urlparse
+
+from supabase import Client, create_client
+
+EXPECTED_SUPABASE_DOMAIN_SUFFIX = ".supabase.co"
+
+
+def get_safe_supabase_url_host(supabase_url: str) -> str:
+    """Return a sanitized Supabase API host for logs/errors.
+
+    The Supabase project URL is public configuration, but this helper avoids
+    logging paths, query strings, keys, or the full original env value.
+    """
+    parsed = urlparse(supabase_url)
+    return parsed.hostname or "unparseable-host"
+
+
+def validate_supabase_url(supabase_url: str) -> None:
+    """Fail fast on malformed or DNS-unresolvable Supabase API URLs."""
+    parsed = urlparse(supabase_url)
+    host = parsed.hostname
+
+    if parsed.scheme != "https" or not host:
+        raise ValueError(
+            "SUPABASE_URL debe ser la API URL pública, por ejemplo "
+            "https://<project-ref>.supabase.co. "
+            f"Host detectado: {host or 'unparseable-host'}."
+        )
+
+    if not host.endswith(EXPECTED_SUPABASE_DOMAIN_SUFFIX):
+        raise ValueError(
+            "SUPABASE_URL no parece una API URL de Supabase. "
+            "Usa https://<project-ref>.supabase.co, no el host de Postgres ni otro endpoint. "
+            f"Host detectado: {host}."
+        )
+
+    try:
+        socket.getaddrinfo(host, 443)
+    except socket.gaierror as error:
+        raise ValueError(
+            "SUPABASE_URL apunta a un host que no resuelve por DNS. "
+            f"Host detectado: {host}. Revisa el secret SUPABASE_URL en GitHub Actions."
+        ) from error
 
 
 def get_supabase_client() -> Client:
@@ -16,10 +59,15 @@ def get_supabase_client() -> Client:
     if not supabase_url or not service_role_key:
         raise ValueError("Supabase URL and Service Role Key are required.")
 
+    validate_supabase_url(supabase_url)
+    safe_host = get_safe_supabase_url_host(supabase_url)
+
     try:
-        return create_client(supabase_url, service_role_key)
+        client = create_client(supabase_url, service_role_key)
+        logging.info("Supabase API host validated: %s", safe_host)
+        return client
     except Exception as e:
-        raise Exception(f"Error creating Supabase client: {str(e)}")
+        raise Exception(f"Error creating Supabase client for host {safe_host}: {str(e)}")
 
 def get_existing_cities():
     logging.info("Starting Get Existing Cities from Supabase")

--- a/tests/test_supabase_client.py
+++ b/tests/test_supabase_client.py
@@ -19,9 +19,12 @@ def test_get_supabase_client(mock_create_client, mock_getaddrinfo, monkeypatch):
     mock_create_client.assert_called_once_with('https://example-project.supabase.co', 'test_key')
 
 
-def test_validate_supabase_url_rejects_postgres_host():
+@patch('supabase_client.socket.getaddrinfo')
+def test_validate_supabase_url_rejects_postgres_host(mock_getaddrinfo):
     with pytest.raises(ValueError, match='no parece una API URL de Supabase'):
         supabase_client.validate_supabase_url('https://db.example-project.supabase.co')
+
+    mock_getaddrinfo.assert_not_called()
 
 
 @patch('supabase_client.socket.getaddrinfo', side_effect=socket.gaierror('dns failed'))

--- a/tests/test_supabase_client.py
+++ b/tests/test_supabase_client.py
@@ -1,16 +1,36 @@
+import socket
+from unittest.mock import MagicMock, patch
+
 import pytest
-from unittest.mock import patch, MagicMock
+
 import supabase_client
 
+
+@patch('supabase_client.socket.getaddrinfo')
 @patch('supabase_client.create_client')
-def test_get_supabase_client(mock_create_client, monkeypatch):
-    """Test that get_supabase_client calls create_client with the correct credentials."""
-    monkeypatch.setenv('SUPABASE_URL', 'test_url')
+def test_get_supabase_client(mock_create_client, mock_getaddrinfo, monkeypatch):
+    """Test that get_supabase_client validates URL and calls create_client."""
+    monkeypatch.setenv('SUPABASE_URL', 'https://example-project.supabase.co')
     monkeypatch.setenv('SUPABASE_SERVICE_ROLE_KEY', 'test_key')
 
     supabase_client.get_supabase_client()
 
-    mock_create_client.assert_called_once_with('test_url', 'test_key')
+    mock_getaddrinfo.assert_called_once_with('example-project.supabase.co', 443)
+    mock_create_client.assert_called_once_with('https://example-project.supabase.co', 'test_key')
+
+
+def test_validate_supabase_url_rejects_postgres_host():
+    with pytest.raises(ValueError, match='no parece una API URL de Supabase'):
+        supabase_client.validate_supabase_url('https://db.example-project.supabase.co')
+
+
+@patch('supabase_client.socket.getaddrinfo', side_effect=socket.gaierror('dns failed'))
+def test_validate_supabase_url_rejects_unresolvable_host(mock_getaddrinfo):
+    with pytest.raises(ValueError, match='no resuelve por DNS'):
+        supabase_client.validate_supabase_url('https://example-project.supabase.co')
+
+    mock_getaddrinfo.assert_called_once_with('example-project.supabase.co', 443)
+
 
 @patch('supabase_client.get_supabase_client')
 def test_get_existing_cities_success(mock_get_supabase_client):
@@ -25,12 +45,13 @@ def test_get_existing_cities_success(mock_get_supabase_client):
     assert len(cities) == 1
     assert cities[0]['id'] == 1
 
+
 @patch('supabase_client.get_supabase_client')
 def test_get_existing_cities_error(mock_get_supabase_client):
     """Test an error during fetching of existing cities."""
     mock_supabase = MagicMock()
-    mock_supabase.table.return_value.select.return_value.execute.side_effect = Exception("DB Error")
+    mock_supabase.table.return_value.select.return_value.execute.side_effect = Exception('DB Error')
     mock_get_supabase_client.return_value = mock_supabase
 
-    with pytest.raises(Exception, match="Failed to get existing cities from Supabase: DB Error"):
+    with pytest.raises(Exception, match='Failed to get existing cities from Supabase: DB Error'):
         supabase_client.get_existing_cities()


### PR DESCRIPTION
## Summary

Follow-up incident hardening after the manual WAQI recovery run failed before reaching WAQI.

Observed runtime failure:

```text
Failed to get existing cities from Supabase: [Errno 11001] getaddrinfo failed
```

This happens while reading `cities`, before station fetches or inserts. The likely root cause is a misconfigured `SUPABASE_URL` GitHub Actions secret: wrong/old project URL, malformed host, Postgres host instead of API URL, or DNS-unresolvable Supabase host.

## Change

- Adds safe `SUPABASE_URL` preflight validation before creating the Supabase client.
- Requires API URL shape: `https://<project-ref>.supabase.co`.
- Rejects likely wrong endpoints such as `db.<project-ref>.supabase.co`.
- Checks DNS resolution for the host before the pipeline starts normal DB work.
- Logs only a sanitized host, never keys/tokens.
- Adds tests for valid API URL, Postgres-host rejection, and DNS failure.
- Updates runtime docs with the Supabase URL incident diagnosis.

## Contract / safety

No changes to:
- Supabase schema
- RPC `get_latest_air_quality_per_city`
- WAQI station mapping
- frontend repo
- secret names

This does not fix the secret automatically; it makes the failure immediate and actionable.

## Required operational fix

Update GitHub Actions secret `SUPABASE_URL` in `elelier/airquality_pipeline` to the live MtyRespira Supabase API URL:

```text
https://<project-ref>.supabase.co
```

It must be the project that contains:

- `public.cities`
- `public.air_quality_readings`
- `public.get_latest_air_quality_per_city()`

Then rerun manual workflow:

- `force_update=true`
- `provider=waqi`

## Validation

Expected CI:

- `pytest`

Post-merge/manual validation:

```sql
select now(), count(*), max(reading_timestamp), now()-max(reading_timestamp)::timestamptz from public.air_quality_readings;
select * from public.get_latest_air_quality_per_city();
```

Then hard refresh/incognito on `https://mtyrespira.elelier.com/`.