### PR TITLE
Fix WAQI aliases for MtyRespira city names

### DIFF
--- a/tests/test_waqi_api.py
+++ b/tests/test_waqi_api.py
@@ -32,6 +32,15 @@ EXPECTED_STATION_IDS = {
     "Cadereyta Jimenez": "10950",
 }
 
+EXPECTED_ALIAS_STATION_IDS = {
+    "García": "6495",
+    "Ciudad Benito Juárez": "8113",
+    "Benito Juarez": "8113",
+    "Benito Juárez": "8113",
+    "Cadereyta Jiménez": "10950",
+    "Cadereyta": "10950",
+}
+
 
 def test_expected_active_api_names_are_covered_by_mapping_registry():
     assert waqi_api.EXPECTED_ACTIVE_API_NAMES == (
@@ -66,7 +75,10 @@ def test_station_mapping_snapshot_marks_all_expected_cities_verified():
         assert by_api_name[api_name]["verified"] is True
         assert by_api_name[api_name]["evidence"]
 
-    assert waqi_api.WAQI_STATION_BY_API_NAME["Ciudad Benito Juárez"] == "8113"
+
+def test_station_mapping_supports_known_supabase_name_aliases():
+    for api_name, station_id in EXPECTED_ALIAS_STATION_IDS.items():
+        assert waqi_api.WAQI_STATION_BY_API_NAME[api_name] == station_id
 
 
 def test_normalize_waqi_payload_success():

--- a/waqi_api.py
+++ b/waqi_api.py
@@ -33,9 +33,14 @@ WAQI_STATION_BY_API_NAME = {
     "Santa Catarina": "6491",
     "General Escobedo": "6496",
     "Garcia": "6495",
+    "García": "6495",
     "Ciudad Benito Juarez": "8113",
     "Ciudad Benito Juárez": "8113",
+    "Benito Juarez": "8113",
+    "Benito Juárez": "8113",
     "Cadereyta Jimenez": "10950",
+    "Cadereyta Jiménez": "10950",
+    "Cadereyta": "10950",
 }
 
 WAQI_STATION_EVIDENCE = {


### PR DESCRIPTION
## Summary

Fixes a likely naming drift cause for MtyRespira cities that appear in the frontend selector but are missing from the RPC response after recovery.

Observed symptom:

- `Cadereyta`, `Benito Juarez`, and `Garcia` can show frontend degradation such as:
  - `La ciudad Garcia no aparece en la respuesta de calidad del aire.`

Diagnosis from code review:

- Frontend matches RPC rows by stable `city_id`, not by name.
- That message means the RPC response does not include the expected city id.
- WAQI registry already maps canonical names:
  - `Garcia` -> `6495`
  - `Ciudad Benito Juarez` -> `8113`
  - `Cadereyta Jimenez` -> `10950`
- If Supabase `cities.api_name` contains shorter or accented variants like `Benito Juarez`, `Benito Juárez`, `Cadereyta`, `Cadereyta Jiménez`, or `García`, the pipeline treats them as `station_not_mapped`, inserts no reading, and the RPC can omit them.

## Change

- Adds explicit WAQI aliases for known Supabase/front naming variants:
  - `García` -> `6495`
  - `Benito Juarez` / `Benito Juárez` -> `8113`
  - `Cadereyta` / `Cadereyta Jiménez` -> `10950`
- Adds tests for those alias mappings.

## Contract / safety

No changes to:

- Supabase schema
- `cities`
- `air_quality_readings`
- RPC `get_latest_air_quality_per_city`
- frontend repo
- secret names

This keeps fail-closed validation: WAQI still must return `status=ok`, AQI, timestamp, and coordinates inside Nuevo León before insert.

## Validation

Expected CI:

- `pytest`

Post-merge runtime validation:

1. Run manual workflow:
   - `force_update=true`
   - `provider=waqi`
2. Validate SQL:

```sql
select c.id, c.name, c.api_name, c.is_active, c.last_update_status,
       c.last_successful_update_at, max(r.reading_timestamp) latest,
       count(r.id) readings_count
from public.cities c
left join public.air_quality_readings r on r.city_id = c.id
where c.id in (1,4,5)
group by c.id, c.name, c.api_name, c.is_active, c.last_update_status, c.last_successful_update_at
order by c.id;
```

3. Validate:

```sql
select * from public.get_latest_air_quality_per_city()
where city_id in (1,4,5);
```

4. Hard refresh `https://mtyrespira.elelier.com/` and confirm those cities no longer show `no aparece en la respuesta`.

## Rollback

Revert this PR. If reverted and Supabase uses the shorter/accented `api_name` values, these cities may return to `station_not_mapped` and stay absent from the RPC.