### PR TITLE
Add RPC contract smoke health check

### DIFF
--- a/.github/workflows/air-quality-workflow.yml
+++ b/.github/workflows/air-quality-workflow.yml
@@ -22,6 +22,14 @@ on:
         options:
           - 'waqi'
           - 'airvisual'
+      rpc_contract_health:
+        description: 'Run read-only RPC contract/freshness health check after tests'
+        required: false
+        default: 'false'
+        type: choice
+        options:
+          - 'false'
+          - 'true'
 
 jobs:
   test:
@@ -45,7 +53,7 @@ jobs:
 
   build:
     runs-on: windows-latest
-    if: github.event_name != 'pull_request'
+    if: github.event_name != 'pull_request' && github.event.inputs.rpc_contract_health != 'true'
     env:
       AIR_QUALITY_PROVIDER: ${{ github.event.inputs.provider || 'waqi' }}
     steps:
@@ -96,3 +104,34 @@ jobs:
         with:
           name: pipeline-log
           path: pipeline.log
+
+  rpc-contract-health:
+    runs-on: windows-latest
+    if: github.event_name == 'workflow_dispatch' && github.event.inputs.rpc_contract_health == 'true'
+    steps:
+      - uses: actions/checkout@v4
+      - name: Set up Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: '3.11'
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r requirements.txt
+      - name: Run tests
+        env:
+          SKIP_PIPELINE_DELAYS: '1'
+          AIR_QUALITY_PROVIDER: waqi
+        run: pytest
+      - name: Run RPC contract health check
+        env:
+          SUPABASE_URL: ${{ secrets.SUPABASE_URL }}
+          SUPABASE_SERVICE_ROLE_KEY: ${{ secrets.SUPABASE_SERVICE_ROLE_KEY }}
+        run: python scripts/rpc_contract_health.py | tee rpc-contract-health.log
+        shell: bash
+      - name: Upload RPC contract health log
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: rpc-contract-health-log
+          path: rpc-contract-health.log

--- a/docs/pipeline-runtime-operations.md
+++ b/docs/pipeline-runtime-operations.md
@@ -42,6 +42,11 @@ For AirVisual fallback runs:
 - `SUPABASE_URL`
 - `SUPABASE_SERVICE_ROLE_KEY`
 
+For the read-only RPC contract health check:
+
+- `SUPABASE_URL`
+- `SUPABASE_SERVICE_ROLE_KEY`
+
 `SUPABASE_URL` must be the public API URL:
 
 ```text
@@ -93,6 +98,70 @@ When data is stale, run the workflow manually with:
 
 This bypasses the timestamp interval check and attempts to refresh all active cities.
 
+## RPC contract health check
+
+Use `scripts/rpc_contract_health.py` to verify the shared read contract exposed by `get_latest_air_quality_per_city` without writing to Supabase.
+
+The check validates:
+
+- RPC response is an array.
+- Expected columns are present.
+- `city_id` is numeric and unique.
+- The current expected active city IDs are present: `1,4,5,6,7,9,11,12,13`.
+- Healthy rows have non-null `aqi_us`.
+- `reading_timestamp` parses as an offset-aware UTC timestamp.
+- `last_successful_update_at` parses as an offset-aware UTC timestamp when present.
+- Freshness is degraded after 2 hours and unhealthy after 6 hours by default.
+
+Run locally with production credentials already available in the environment:
+
+```bash
+python scripts/rpc_contract_health.py
+```
+
+Optional overrides:
+
+```bash
+EXPECTED_ACTIVE_CITY_IDS=1,4,5,6,7,9,11,12,13 \
+RPC_FRESHNESS_WARN_HOURS=2 \
+RPC_FRESHNESS_FAIL_HOURS=6 \
+python scripts/rpc_contract_health.py
+```
+
+Run from GitHub Actions manually:
+
+- Open **Air Quality Pipeline** workflow.
+- Use **Run workflow**.
+- Set `rpc_contract_health=true`.
+- Leave `force_update=false` unless doing a separate recovery run.
+
+The manual health job runs tests first, then runs the read-only RPC check and uploads `rpc-contract-health.log`.
+
+Exit codes:
+
+- `0`: healthy or degraded. Degraded means contract is intact, but one or more readings are older than the warning threshold.
+- `1`: unhealthy contract/freshness. Examples: missing expected city ID, duplicate `city_id`, null `aqi_us`, invalid timestamp, or stale reading beyond the fail threshold.
+- `2`: configuration or connection failure. Examples: missing Supabase env vars, wrong `SUPABASE_URL`, DNS failure, or RPC call failure.
+
+Sample healthy output shape:
+
+```json
+{
+  "status": "healthy",
+  "rpc": "get_latest_air_quality_per_city",
+  "expected_city_ids": [1, 4, 5, 6, 7, 9, 11, 12, 13],
+  "returned_city_ids": [1, 4, 5, 6, 7, 9, 11, 12, 13],
+  "errors": [],
+  "warnings": []
+}
+```
+
+Rollback:
+
+- Revert the PR that introduced `scripts/rpc_contract_health.py`, its tests, docs, and workflow job.
+- No Supabase schema, RPC shape, table data, or frontend runtime change is required to roll back this check.
+- If this check fails after rollback, continue using the SQL post-run checks below because they query the same contract boundary manually.
+
 ## Healthy run criteria
 
 A run is healthy when:
@@ -139,6 +208,7 @@ For WAQI, each fetch also logs the mapped station as `@station_id` or `unmapped`
 - WAQI payload is missing AQI, timestamp, or coordinates.
 - WAQI station coordinates are outside Nuevo León.
 - Supabase insert or update failed.
+- RPC health check fails because an expected active city is missing, duplicated, stale, or has null AQI.
 - Frontend reads a valid RPC response but rejects or hides rows because of stale-data thresholds or cache.
 
 ## Incident note: public data missing after WAQI coverage rollout

--- a/scripts/rpc_contract_health.py
+++ b/scripts/rpc_contract_health.py
@@ -1,0 +1,260 @@
+"""Operational smoke check for get_latest_air_quality_per_city.
+
+Read-only CLI intended for manual GitHub Actions runs and local incident checks.
+It validates the public RPC contract shape and freshness without writing to Supabase.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import sys
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from typing import Any
+
+from supabase_client import get_supabase_client
+
+RPC_NAME = "get_latest_air_quality_per_city"
+EXPECTED_COLUMNS = {
+    "city_id",
+    "city_name",
+    "api_name",
+    "latitude",
+    "longitude",
+    "reading_timestamp",
+    "aqi_us",
+    "main_pollutant_us",
+    "temperature_c",
+    "humidity_percent",
+    "wind_speed_ms",
+    "wind_direction_deg",
+    "weather_icon",
+    "last_successful_update_at",
+}
+DEFAULT_EXPECTED_ACTIVE_CITY_IDS = {1, 4, 5, 6, 7, 9, 11, 12, 13}
+DEFAULT_WARN_HOURS = 2.0
+DEFAULT_FAIL_HOURS = 6.0
+
+
+@dataclass(frozen=True)
+class FreshnessThresholds:
+    warn_hours: float = DEFAULT_WARN_HOURS
+    fail_hours: float = DEFAULT_FAIL_HOURS
+
+
+def parse_expected_city_ids(value: str | None) -> set[int]:
+    if not value:
+        return set(DEFAULT_EXPECTED_ACTIVE_CITY_IDS)
+
+    expected: set[int] = set()
+    for raw_item in value.split(","):
+        item = raw_item.strip()
+        if not item:
+            continue
+        expected.add(int(item))
+    return expected
+
+
+def parse_utc_timestamp(value: Any) -> datetime:
+    if not isinstance(value, str) or not value.strip():
+        raise ValueError("timestamp must be a non-empty string")
+
+    normalized = value.strip().replace("Z", "+00:00")
+    parsed = datetime.fromisoformat(normalized)
+    if parsed.tzinfo is None:
+        raise ValueError("timestamp must include UTC offset")
+    return parsed.astimezone(timezone.utc)
+
+
+def _freshness_hours(reading_timestamp: datetime, now_utc: datetime) -> float:
+    return (now_utc - reading_timestamp).total_seconds() / 3600
+
+
+def fetch_rpc_rows() -> list[dict[str, Any]]:
+    response = get_supabase_client().rpc(RPC_NAME).execute()
+    data = getattr(response, "data", None)
+    if not isinstance(data, list):
+        raise ValueError("Supabase RPC response is not an array")
+    return data
+
+
+def evaluate_rpc_contract(
+    rows: Any,
+    *,
+    expected_city_ids: set[int] | None = None,
+    thresholds: FreshnessThresholds | None = None,
+    now_utc: datetime | None = None,
+) -> dict[str, Any]:
+    expected_ids = expected_city_ids or set(DEFAULT_EXPECTED_ACTIVE_CITY_IDS)
+    freshness_thresholds = thresholds or FreshnessThresholds()
+    checked_at = now_utc or datetime.now(timezone.utc)
+    if checked_at.tzinfo is None:
+        checked_at = checked_at.replace(tzinfo=timezone.utc)
+    checked_at = checked_at.astimezone(timezone.utc)
+
+    errors: list[str] = []
+    warnings: list[str] = []
+    city_ids: list[int] = []
+    freshness_by_city: dict[str, float] = {}
+
+    if not isinstance(rows, list):
+        return {
+            "status": "unhealthy",
+            "rpc": RPC_NAME,
+            "checked_at_utc": checked_at.isoformat(),
+            "expected_city_ids": sorted(expected_ids),
+            "returned_city_ids": [],
+            "errors": ["RPC response must be an array"],
+            "warnings": [],
+            "freshness_hours_by_city_id": {},
+        }
+
+    for index, row in enumerate(rows):
+        if not isinstance(row, dict):
+            errors.append(f"row[{index}] is not an object")
+            continue
+
+        missing_columns = sorted(EXPECTED_COLUMNS - set(row.keys()))
+        if missing_columns:
+            errors.append(f"row[{index}] missing columns: {', '.join(missing_columns)}")
+
+        city_id = row.get("city_id")
+        if isinstance(city_id, bool) or not isinstance(city_id, int):
+            errors.append(f"row[{index}] city_id must be numeric")
+            continue
+        city_ids.append(city_id)
+
+        if row.get("aqi_us") is None:
+            errors.append(f"city_id {city_id} has null aqi_us")
+
+        try:
+            reading_timestamp = parse_utc_timestamp(row.get("reading_timestamp"))
+            age_hours = _freshness_hours(reading_timestamp, checked_at)
+            freshness_by_city[str(city_id)] = round(age_hours, 3)
+            if age_hours > freshness_thresholds.fail_hours:
+                errors.append(
+                    f"city_id {city_id} reading_timestamp is stale: "
+                    f"{age_hours:.2f}h > {freshness_thresholds.fail_hours:.2f}h"
+                )
+            elif age_hours > freshness_thresholds.warn_hours:
+                warnings.append(
+                    f"city_id {city_id} reading_timestamp is degraded: "
+                    f"{age_hours:.2f}h > {freshness_thresholds.warn_hours:.2f}h"
+                )
+        except Exception as exc:  # noqa: BLE001 - surface parse cause in operator output.
+            errors.append(f"city_id {city_id} has invalid reading_timestamp: {exc}")
+
+        try:
+            if row.get("last_successful_update_at") is not None:
+                parse_utc_timestamp(row.get("last_successful_update_at"))
+        except Exception as exc:  # noqa: BLE001 - surface parse cause in operator output.
+            errors.append(f"city_id {city_id} has invalid last_successful_update_at: {exc}")
+
+    duplicate_ids = sorted({city_id for city_id in city_ids if city_ids.count(city_id) > 1})
+    if duplicate_ids:
+        errors.append(f"duplicate city_id values: {duplicate_ids}")
+
+    returned_ids = set(city_ids)
+    missing_expected_ids = sorted(expected_ids - returned_ids)
+    if missing_expected_ids:
+        errors.append(f"missing expected active city_ids: {missing_expected_ids}")
+
+    status = "healthy"
+    if errors:
+        status = "unhealthy"
+    elif warnings:
+        status = "degraded"
+
+    return {
+        "status": status,
+        "rpc": RPC_NAME,
+        "checked_at_utc": checked_at.isoformat(),
+        "expected_city_ids": sorted(expected_ids),
+        "returned_city_ids": sorted(returned_ids),
+        "row_count": len(rows),
+        "errors": errors,
+        "warnings": warnings,
+        "freshness_hours_by_city_id": freshness_by_city,
+        "thresholds": {
+            "warn_hours": freshness_thresholds.warn_hours,
+            "fail_hours": freshness_thresholds.fail_hours,
+        },
+    }
+
+
+def build_human_summary(result: dict[str, Any]) -> str:
+    status = str(result.get("status", "unknown")).upper()
+    returned = result.get("returned_city_ids", [])
+    expected = result.get("expected_city_ids", [])
+    errors = result.get("errors", [])
+    warnings = result.get("warnings", [])
+
+    lines = [
+        f"RPC contract health: {status}",
+        f"RPC: {result.get('rpc', RPC_NAME)}",
+        f"Expected city IDs: {expected}",
+        f"Returned city IDs: {returned}",
+    ]
+    if warnings:
+        lines.append("Warnings:")
+        lines.extend(f"- {warning}" for warning in warnings)
+    if errors:
+        lines.append("Errors:")
+        lines.extend(f"- {error}" for error in errors)
+    return "\n".join(lines)
+
+
+def _thresholds_from_env() -> FreshnessThresholds:
+    return FreshnessThresholds(
+        warn_hours=float(os.getenv("RPC_FRESHNESS_WARN_HOURS", DEFAULT_WARN_HOURS)),
+        fail_hours=float(os.getenv("RPC_FRESHNESS_FAIL_HOURS", DEFAULT_FAIL_HOURS)),
+    )
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description="Check MtyRespira RPC contract and freshness.")
+    parser.add_argument(
+        "--expected-city-ids",
+        default=os.getenv("EXPECTED_ACTIVE_CITY_IDS"),
+        help="Comma-separated active city IDs. Defaults to current 9 active municipalities.",
+    )
+    parser.add_argument(
+        "--json-only",
+        action="store_true",
+        help="Print only JSON output.",
+    )
+    args = parser.parse_args(argv)
+
+    try:
+        rows = fetch_rpc_rows()
+        result = evaluate_rpc_contract(
+            rows,
+            expected_city_ids=parse_expected_city_ids(args.expected_city_ids),
+            thresholds=_thresholds_from_env(),
+        )
+    except Exception as exc:  # noqa: BLE001 - operational CLI must classify connection/config failures.
+        result = {
+            "status": "config_error",
+            "rpc": RPC_NAME,
+            "checked_at_utc": datetime.now(timezone.utc).isoformat(),
+            "errors": [str(exc)],
+            "warnings": [],
+        }
+        print(json.dumps(result, indent=2, sort_keys=True))
+        if not args.json_only:
+            print("\nRPC contract health: CONFIG_ERROR")
+        return 2
+
+    print(json.dumps(result, indent=2, sort_keys=True))
+    if not args.json_only:
+        print("\n" + build_human_summary(result))
+
+    if result["status"] == "unhealthy":
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/test_rpc_contract_health.py
+++ b/tests/test_rpc_contract_health.py
@@ -1,0 +1,169 @@
+from datetime import datetime, timedelta, timezone
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from scripts.rpc_contract_health import (
+    DEFAULT_EXPECTED_ACTIVE_CITY_IDS,
+    EXPECTED_COLUMNS,
+    FreshnessThresholds,
+    evaluate_rpc_contract,
+    fetch_rpc_rows,
+    main,
+    parse_utc_timestamp,
+)
+
+
+NOW = datetime(2026, 5, 7, 13, 0, tzinfo=timezone.utc)
+
+
+def make_row(city_id: int, **overrides):
+    row = {
+        "city_id": city_id,
+        "city_name": f"City {city_id}",
+        "api_name": f"City {city_id}",
+        "latitude": 25.6,
+        "longitude": -100.3,
+        "reading_timestamp": (NOW - timedelta(minutes=45)).isoformat(),
+        "aqi_us": 74,
+        "main_pollutant_us": "pm25",
+        "temperature_c": None,
+        "humidity_percent": None,
+        "wind_speed_ms": None,
+        "wind_direction_deg": None,
+        "weather_icon": None,
+        "last_successful_update_at": (NOW - timedelta(minutes=30)).isoformat(),
+    }
+    row.update(overrides)
+    assert EXPECTED_COLUMNS.issubset(row.keys())
+    return row
+
+
+def make_all_rows(**overrides):
+    return [make_row(city_id, **overrides) for city_id in sorted(DEFAULT_EXPECTED_ACTIVE_CITY_IDS)]
+
+
+def test_evaluate_rpc_contract_success_for_9_expected_ids():
+    result = evaluate_rpc_contract(make_all_rows(), now_utc=NOW)
+
+    assert result["status"] == "healthy"
+    assert result["returned_city_ids"] == sorted(DEFAULT_EXPECTED_ACTIVE_CITY_IDS)
+    assert result["errors"] == []
+    assert result["warnings"] == []
+
+
+def test_evaluate_rpc_contract_fails_missing_expected_city():
+    rows = [row for row in make_all_rows() if row["city_id"] != 13]
+
+    result = evaluate_rpc_contract(rows, now_utc=NOW)
+
+    assert result["status"] == "unhealthy"
+    assert "missing expected active city_ids: [13]" in result["errors"]
+
+
+def test_evaluate_rpc_contract_fails_null_aqi_for_expected_city():
+    rows = make_all_rows()
+    rows[0]["aqi_us"] = None
+
+    result = evaluate_rpc_contract(rows, now_utc=NOW)
+
+    assert result["status"] == "unhealthy"
+    assert f"city_id {rows[0]['city_id']} has null aqi_us" in result["errors"]
+
+
+def test_evaluate_rpc_contract_degraded_when_reading_is_warning_stale():
+    rows = make_all_rows(reading_timestamp=(NOW - timedelta(hours=3)).isoformat())
+
+    result = evaluate_rpc_contract(
+        rows,
+        now_utc=NOW,
+        thresholds=FreshnessThresholds(warn_hours=2, fail_hours=6),
+    )
+
+    assert result["status"] == "degraded"
+    assert result["errors"] == []
+    assert result["warnings"]
+
+
+def test_evaluate_rpc_contract_fails_when_reading_is_severely_stale():
+    rows = make_all_rows(reading_timestamp=(NOW - timedelta(hours=7)).isoformat())
+
+    result = evaluate_rpc_contract(
+        rows,
+        now_utc=NOW,
+        thresholds=FreshnessThresholds(warn_hours=2, fail_hours=6),
+    )
+
+    assert result["status"] == "unhealthy"
+    assert any("reading_timestamp is stale" in error for error in result["errors"])
+
+
+def test_evaluate_rpc_contract_fails_bad_shape():
+    result = evaluate_rpc_contract({"data": []}, now_utc=NOW)
+
+    assert result["status"] == "unhealthy"
+    assert result["errors"] == ["RPC response must be an array"]
+
+
+def test_evaluate_rpc_contract_fails_bad_timestamp():
+    rows = make_all_rows(reading_timestamp="not-a-timestamp")
+
+    result = evaluate_rpc_contract(rows, now_utc=NOW)
+
+    assert result["status"] == "unhealthy"
+    assert any("invalid reading_timestamp" in error for error in result["errors"])
+
+
+def test_evaluate_rpc_contract_fails_duplicate_city_id():
+    rows = make_all_rows()
+    rows.append(make_row(1))
+
+    result = evaluate_rpc_contract(rows, now_utc=NOW)
+
+    assert result["status"] == "unhealthy"
+    assert "duplicate city_id values: [1]" in result["errors"]
+
+
+def test_parse_utc_timestamp_rejects_naive_timestamp():
+    with pytest.raises(ValueError, match="UTC offset"):
+        parse_utc_timestamp("2026-05-07T13:00:00")
+
+
+def test_fetch_rpc_rows_uses_read_only_rpc_call():
+    mock_response = SimpleNamespace(data=make_all_rows())
+    mock_client = MagicMock()
+    mock_client.rpc.return_value.execute.return_value = mock_response
+
+    with patch("scripts.rpc_contract_health.get_supabase_client", return_value=mock_client):
+        rows = fetch_rpc_rows()
+
+    assert len(rows) == 9
+    mock_client.rpc.assert_called_once_with("get_latest_air_quality_per_city")
+    mock_client.table.assert_not_called()
+
+
+def test_fetch_rpc_rows_rejects_non_array_response():
+    mock_client = MagicMock()
+    mock_client.rpc.return_value.execute.return_value = SimpleNamespace(data={"bad": "shape"})
+
+    with patch("scripts.rpc_contract_health.get_supabase_client", return_value=mock_client):
+        with pytest.raises(ValueError, match="not an array"):
+            fetch_rpc_rows()
+
+
+def test_main_exit_codes_for_healthy_degraded_unhealthy_and_config_error(capsys):
+    with patch("scripts.rpc_contract_health.fetch_rpc_rows", return_value=make_all_rows()):
+        assert main(["--json-only"]) == 0
+
+    with patch(
+        "scripts.rpc_contract_health.fetch_rpc_rows",
+        return_value=make_all_rows(reading_timestamp=(NOW - timedelta(hours=7)).isoformat()),
+    ):
+        assert main(["--json-only"]) == 1
+
+    with patch("scripts.rpc_contract_health.fetch_rpc_rows", side_effect=RuntimeError("boom")):
+        assert main(["--json-only"]) == 2
+
+    captured = capsys.readouterr()
+    assert "SUPABASE_SERVICE_ROLE_KEY" not in captured.out


### PR DESCRIPTION
## Summary
- Add read-only `scripts/rpc_contract_health.py` for `get_latest_air_quality_per_city` contract and freshness checks.
- Validate expected active IDs `1,4,5,6,7,9,11,12,13`, required RPC columns, unique numeric `city_id`, non-null `aqi_us`, parseable UTC timestamps, and freshness thresholds.
- Add offline pytest coverage for healthy, missing city, null AQI, warning/degraded stale, severely stale, bad shape, bad timestamp, duplicate city IDs, and RPC read-only invocation.
- Add optional manual GitHub Actions job `rpc-contract-health` gated by `workflow_dispatch` input `rpc_contract_health=true`; hourly pipeline remains non-blocked.
- Document local/manual usage, exit codes, sample output, incident interpretation, and rollback in `docs/pipeline-runtime-operations.md`.

## Contract / runtime impact
- No Supabase schema changes.
- No RPC shape changes.
- No live writes.
- No frontend code changes.
- Uses existing `SUPABASE_URL` + `SUPABASE_SERVICE_ROLE_KEY` only in backend/ops context.

## Validation
- PR CI should run `pytest` on pull request.
- Manual runtime check after merge: run **Air Quality Pipeline** workflow with `rpc_contract_health=true` and review `rpc-contract-health.log`.

## Rollback
- Revert this PR. It only adds an ops smoke check, tests, workflow job, and docs; no data/schema/RPC/frontend rollback required.