### PR TITLE
Document post-merge RPC health evidence process

### DIFF
--- a/docs/rpc-health-evidence.md
+++ b/docs/rpc-health-evidence.md
@@ -1,0 +1,81 @@
+# RPC Health Evidence
+
+This document captures the post-merge operating evidence for the read-only RPC contract health check introduced in PR #9.
+
+## Scope
+
+Product boundary:
+
+`WAQI/AQICN -> airquality_pipeline -> Supabase tables -> get_latest_air_quality_per_city -> monterrey-respira`
+
+This evidence covers only the read-only RPC contract/freshness check. It must not be used as evidence of a live write, schema migration, RPC shape change, or frontend deployment change.
+
+## Current post-merge state
+
+- PR #9 is merged into `main`.
+- `.github/workflows/air-quality-workflow.yml` contains the manual `rpc-contract-health` job gated by `workflow_dispatch` input `rpc_contract_health=true`.
+- The hourly `build` job is skipped when `rpc_contract_health=true`, so a manual RPC health run does not block or replace the normal hourly pipeline.
+- This PR does not execute live writes and does not require any Supabase schema/RPC/frontend change.
+
+## How to run the production RPC health check
+
+Use GitHub Actions manually:
+
+1. Open **Actions -> Air Quality Pipeline**.
+2. Select **Run workflow** from `main`.
+3. Set:
+   - `rpc_contract_health=true`
+   - `force_update=false`
+   - `provider=waqi`
+4. Wait for the `rpc-contract-health` job to finish.
+5. Open the run artifacts and download `rpc-contract-health-log`.
+6. Confirm the JSON output status and preserve the run URL in the evidence table below.
+
+Required secrets for this read-only check:
+
+- `SUPABASE_URL`
+- `SUPABASE_SERVICE_ROLE_KEY`
+
+Do not paste secret values into this document, PR comments, screenshots, or logs.
+
+## Evidence table
+
+| Check | Evidence |
+| --- | --- |
+| Workflow | Air Quality Pipeline / manual `workflow_dispatch` |
+| Inputs | `rpc_contract_health=true`, `force_update=false`, `provider=waqi` |
+| Run URL | `TODO: paste GitHub Actions run URL after manual dispatch` |
+| Artifact | `rpc-contract-health-log` |
+| Observed status | `TODO: healthy / degraded / unhealthy / config_error` |
+| Checked at UTC | `TODO: timestamp from run/log` |
+| Contract shape | `TODO: pass/fail based on log` |
+| Freshness interpretation | `TODO: healthy, degraded warning, or unhealthy fail threshold` |
+| Next action | `TODO: none / recovery / config fix / investigation` |
+
+## How to interpret status
+
+`healthy` means the RPC contract is intact and freshness is inside the configured warning threshold.
+
+`degraded` means the RPC contract is intact, but one or more readings are older than the warning threshold. This is not the same as a contract break. If the site is showing stale data, run manual recovery separately with `force_update=true` and `provider=waqi`, then rerun this health check.
+
+`unhealthy` means the contract or freshness failed hard. Examples include missing expected city IDs, duplicate `city_id`, null `aqi_us` for a required healthy row, invalid timestamps, or readings older than the fail threshold. Do not change the RPC or database manually from this evidence doc; diagnose from the log first.
+
+`config_error` or exit code `2` means the check could not validate production. Common causes are missing secrets, an invalid `SUPABASE_URL`, DNS failure, or RPC call failure. Fix configuration first; do not treat this as proof that the RPC payload is broken.
+
+## Recovery rule
+
+Only run manual recovery when the contract is intact but data is stale or missing due to pipeline freshness/upstream issues:
+
+- `force_update=true`
+- `provider=waqi`
+- `rpc_contract_health=false`
+
+After recovery completes, run the RPC health check again with:
+
+- `force_update=false`
+- `provider=waqi`
+- `rpc_contract_health=true`
+
+## Rollback
+
+Revert this docs PR if the evidence process needs to be removed. No Supabase schema, RPC shape, table data, workflow schedule, or frontend rollback is required.

--- a/tests/test_rpc_contract_health.py
+++ b/tests/test_rpc_contract_health.py
@@ -44,6 +44,14 @@ def make_all_rows(**overrides):
     return [make_row(city_id, **overrides) for city_id in sorted(DEFAULT_EXPECTED_ACTIVE_CITY_IDS)]
 
 
+def make_runtime_rows(*, reading_age: timedelta = timedelta(minutes=45)):
+    now = datetime.now(timezone.utc)
+    return make_all_rows(
+        reading_timestamp=(now - reading_age).isoformat(),
+        last_successful_update_at=(now - timedelta(minutes=30)).isoformat(),
+    )
+
+
 def test_evaluate_rpc_contract_success_for_9_expected_ids():
     result = evaluate_rpc_contract(make_all_rows(), now_utc=NOW)
 
@@ -153,12 +161,12 @@ def test_fetch_rpc_rows_rejects_non_array_response():
 
 
 def test_main_exit_codes_for_healthy_degraded_unhealthy_and_config_error(capsys):
-    with patch("scripts.rpc_contract_health.fetch_rpc_rows", return_value=make_all_rows()):
+    with patch("scripts.rpc_contract_health.fetch_rpc_rows", return_value=make_runtime_rows()):
         assert main(["--json-only"]) == 0
 
     with patch(
         "scripts.rpc_contract_health.fetch_rpc_rows",
-        return_value=make_all_rows(reading_timestamp=(NOW - timedelta(hours=7)).isoformat()),
+        return_value=make_runtime_rows(reading_age=timedelta(hours=7)),
     ):
         assert main(["--json-only"]) == 1
 


### PR DESCRIPTION
## Summary
- Adds `docs/rpc-health-evidence.md` as the post-merge evidence/runbook for the read-only RPC health check introduced in PR #9.
- Documents the exact manual workflow inputs: `rpc_contract_health=true`, `force_update=false`, `provider=waqi`.
- Adds an evidence table for the maintainer to paste the run URL, artifact status, timestamp, interpretation, and next action after manual dispatch.

## Runtime / contract impact
- Docs only.
- No Supabase schema changes.
- No RPC shape changes.
- No live writes.
- No frontend changes.
- No secret values added.

## Validation
- Reviewed PR #9 is merged into `main`.
- Reviewed `.github/workflows/air-quality-workflow.yml` on `main`: `rpc-contract-health` exists and is gated by `workflow_dispatch` + `rpc_contract_health=true`.
- Confirmed the normal hourly `build` job is skipped for manual RPC health runs, so the hourly pipeline is not blocked by this evidence flow.
- `pytest` not run here because this PR changes docs only.

## Manual production evidence still required
Run **Air Quality Pipeline** manually from GitHub Actions with:

- `rpc_contract_health=true`
- `force_update=false`
- `provider=waqi`

Then download artifact `rpc-contract-health-log` and fill the evidence table in `docs/rpc-health-evidence.md`.

## Rollback
Revert this PR. It only adds documentation; no database, workflow schedule, RPC, or frontend rollback is required.