### PR TITLE
fix: repair rpc health import path

### DIFF
--- a/scripts/rpc_contract_health.py
+++ b/scripts/rpc_contract_health.py
@@ -12,7 +12,12 @@ import os
 import sys
 from dataclasses import dataclass
 from datetime import datetime, timezone
+from pathlib import Path
 from typing import Any
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
 
 from supabase_client import get_supabase_client
 

--- a/tests/test_rpc_contract_health.py
+++ b/tests/test_rpc_contract_health.py
@@ -1,4 +1,6 @@
 from datetime import datetime, timedelta, timezone
+from pathlib import Path
+import runpy
 from types import SimpleNamespace
 from unittest.mock import MagicMock, patch
 
@@ -16,6 +18,13 @@ from scripts.rpc_contract_health import (
 
 
 NOW = datetime(2026, 5, 7, 13, 0, tzinfo=timezone.utc)
+
+
+def test_rpc_contract_health_script_imports_from_scripts_path():
+    script_path = Path(__file__).resolve().parents[1] / "scripts" / "rpc_contract_health.py"
+    namespace = runpy.run_path(str(script_path), run_name="rpc_contract_health_import_test")
+
+    assert namespace["RPC_NAME"] == "get_latest_air_quality_per_city"
 
 
 def make_row(city_id: int, **overrides):


### PR DESCRIPTION
## Summary
- Fixes the manual read-only RPC health check import path when run as python scripts/rpc_contract_health.py in GitHub Actions.
- Adds a regression test that imports the script through its scripts/ path.

## Root cause
- Python sets scripts/ as sys.path[0] for direct script execution, so the root-level supabase_client.py was not importable.

## Validation
- python -m pytest -vv: 53 passed, 6 existing datetime.utcnow deprecation warnings.
- python scripts/rpc_contract_health.py --json-only no longer fails with ModuleNotFoundError; local env returns CONFIG_ERROR because local SUPABASE_URL points at a non-resolving host.

## Rollback
- Revert this PR. It only changes the health-check script import path and its regression test; cron ingestion behavior is unchanged.