### PR TITLE
Story 1.1 — RPC Contract Smoke + Runtime Nullability Verification

### DIFF
--- a/docs/rpc-contract-smoke.md
+++ b/docs/rpc-contract-smoke.md
@@ -1,0 +1,82 @@
+# RPC Contract Smoke — MtyRespira
+
+## Objetivo
+
+Este smoke protege el contrato compartido de la RPC `get_latest_air_quality_per_city`, que conecta:
+
+`pipeline -> Supabase/RPC -> frontend -> UX pública`
+
+La validación evita drift silencioso de columnas, nullability y timestamps antes de que la app pública represente datos incompletos como sanos.
+
+## Smoke local sin red
+
+El smoke canónico sin credenciales usa fixture local:
+
+```bash
+pytest tests/test_latest_air_quality_rpc_contract.py
+```
+
+No llama a Supabase, no usa secretos y no escribe datos.
+
+## Fixture canónico
+
+Fixture:
+
+```text
+tests/fixtures/latest_air_quality_rpc_valid.json
+```
+
+Casos representados:
+
+- Ciudad sana con AQI, contaminante principal, clima, coordenadas y timestamps.
+- Ciudad con campos secundarios `null` para validar degradación controlada.
+- Ciudad con `aqi_us: null` para mantener visible que una fila así no es lectura sana y debe degradar en frontend/UX.
+
+## Columnas esperadas
+
+La RPC debe conservar estas columnas:
+
+- `city_id`
+- `city_name`
+- `api_name`
+- `latitude`
+- `longitude`
+- `reading_timestamp`
+- `aqi_us`
+- `main_pollutant_us`
+- `temperature_c`
+- `humidity_percent`
+- `wind_speed_ms`
+- `wind_direction_deg`
+- `weather_icon`
+- `last_successful_update_at`
+
+## Reglas verificadas
+
+- `city_id`, `city_name`, `api_name` y `reading_timestamp` son requeridos.
+- `city_id` debe ser numérico, estable y único por fila.
+- Todos los campos canónicos deben estar presentes aunque su valor sea `null`.
+- Los campos degradables pueden ser `null`.
+- `reading_timestamp` debe ser parseable y tener offset UTC explícito.
+- `last_successful_update_at` puede ser `null`; si existe, debe ser parseable con offset UTC explícito.
+- `aqi_us: null` queda documentado como caso degradado, no como lectura sana.
+
+## Smoke operativo contra Supabase
+
+El script operativo existente valida la RPC real en modo read-only:
+
+```bash
+python scripts/rpc_contract_health.py
+```
+
+Este comando sí requiere configuración de Supabase del pipeline y debe usarse para incidentes, runs manuales o verificación operativa. No pertenece al smoke local sin red.
+
+## Rollback
+
+Revertir estos archivos no cambia runtime productivo:
+
+- `tests/fixtures/latest_air_quality_rpc_valid.json`
+- `tests/test_latest_air_quality_rpc_contract.py`
+- `docs/rpc-contract-smoke.md`
+
+No hay migraciones, cambios de schema, cambios de RPC ni writes live.

--- a/tests/fixtures/latest_air_quality_rpc_valid.json
+++ b/tests/fixtures/latest_air_quality_rpc_valid.json
@@ -1,0 +1,50 @@
+[
+  {
+    "city_id": 9,
+    "city_name": "Monterrey",
+    "api_name": "Monterrey",
+    "latitude": 25.6866,
+    "longitude": -100.3161,
+    "reading_timestamp": "2026-05-21T16:00:00+00:00",
+    "aqi_us": 42,
+    "main_pollutant_us": "pm25",
+    "temperature_c": 28.4,
+    "humidity_percent": 45,
+    "wind_speed_ms": 2.7,
+    "wind_direction_deg": 120,
+    "weather_icon": "01d",
+    "last_successful_update_at": "2026-05-21T16:13:00+00:00"
+  },
+  {
+    "city_id": 13,
+    "city_name": "Santa Catarina",
+    "api_name": "Santa Catarina",
+    "latitude": null,
+    "longitude": null,
+    "reading_timestamp": "2026-05-21T15:00:00+00:00",
+    "aqi_us": 87,
+    "main_pollutant_us": null,
+    "temperature_c": null,
+    "humidity_percent": null,
+    "wind_speed_ms": null,
+    "wind_direction_deg": null,
+    "weather_icon": null,
+    "last_successful_update_at": null
+  },
+  {
+    "city_id": 1,
+    "city_name": "Cadereyta Jimenez",
+    "api_name": "Cadereyta Jimenez",
+    "latitude": 25.5894,
+    "longitude": -99.9969,
+    "reading_timestamp": "2026-05-21T14:00:00+00:00",
+    "aqi_us": null,
+    "main_pollutant_us": null,
+    "temperature_c": null,
+    "humidity_percent": null,
+    "wind_speed_ms": null,
+    "wind_direction_deg": null,
+    "weather_icon": null,
+    "last_successful_update_at": "2026-05-21T14:58:00+00:00"
+  }
+]

--- a/tests/test_latest_air_quality_rpc_contract.py
+++ b/tests/test_latest_air_quality_rpc_contract.py
@@ -1,0 +1,129 @@
+import json
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from scripts.rpc_contract_health import EXPECTED_COLUMNS, parse_utc_timestamp
+
+FIXTURE_PATH = Path(__file__).parent / "fixtures" / "latest_air_quality_rpc_valid.json"
+
+REQUIRED_FIELDS = {"city_id", "city_name", "api_name", "reading_timestamp"}
+NULLABLE_FIELDS = EXPECTED_COLUMNS - REQUIRED_FIELDS
+NUMERIC_OR_NULL_FIELDS = {
+    "latitude",
+    "longitude",
+    "aqi_us",
+    "temperature_c",
+    "humidity_percent",
+    "wind_speed_ms",
+    "wind_direction_deg",
+}
+STRING_OR_NULL_FIELDS = {
+    "main_pollutant_us",
+    "weather_icon",
+    "last_successful_update_at",
+}
+
+
+def load_fixture() -> list[dict[str, Any]]:
+    with FIXTURE_PATH.open(encoding="utf-8") as fixture_file:
+        data = json.load(fixture_file)
+    assert isinstance(data, list), "Canonical RPC fixture must be an array"
+    return data
+
+
+def test_canonical_rpc_fixture_preserves_expected_shape_and_required_fields():
+    rows = load_fixture()
+
+    assert rows, "Canonical RPC fixture must include at least one row"
+    for index, row in enumerate(rows):
+        assert isinstance(row, dict), f"row[{index}] must be an object"
+        assert EXPECTED_COLUMNS.issubset(row.keys()), (
+            f"row[{index}] missing canonical columns: "
+            f"{sorted(EXPECTED_COLUMNS - set(row.keys()))}"
+        )
+        assert not REQUIRED_FIELDS - row.keys()
+        for field in REQUIRED_FIELDS:
+            assert row[field] is not None, f"row[{index}] {field} must not be null"
+
+
+def test_canonical_rpc_fixture_uses_city_id_as_stable_numeric_identity():
+    rows = load_fixture()
+    city_ids = [row["city_id"] for row in rows]
+
+    assert all(isinstance(city_id, int) and not isinstance(city_id, bool) for city_id in city_ids)
+    assert len(city_ids) == len(set(city_ids)), "city_id values must be unique in RPC rows"
+
+
+def test_canonical_rpc_fixture_documents_nullable_degradable_fields():
+    rows = load_fixture()
+
+    assert any(row["latitude"] is None and row["longitude"] is None for row in rows), (
+        "Fixture must include a row with nullable coordinates to lock degradation behavior"
+    )
+    assert any(row["aqi_us"] is None for row in rows), (
+        "Fixture must include a degraded contractual row with null aqi_us"
+    )
+
+    for index, row in enumerate(rows):
+        for field in NUMERIC_OR_NULL_FIELDS:
+            value = row[field]
+            assert value is None or isinstance(value, (int, float)), (
+                f"row[{index}] {field} must be numeric or null"
+            )
+        for field in STRING_OR_NULL_FIELDS:
+            value = row[field]
+            assert value is None or isinstance(value, str), (
+                f"row[{index}] {field} must be string or null"
+            )
+        for field in NULLABLE_FIELDS:
+            assert field in row, f"row[{index}] {field} must be present even when null"
+
+
+def test_canonical_rpc_fixture_timestamps_are_parseable_explicit_utc():
+    rows = load_fixture()
+
+    for index, row in enumerate(rows):
+        reading_timestamp = parse_utc_timestamp(row["reading_timestamp"])
+        assert reading_timestamp.tzinfo is not None
+        assert reading_timestamp.utcoffset() == timezone.utc.utcoffset(reading_timestamp)
+
+        last_successful_update_at = row["last_successful_update_at"]
+        if last_successful_update_at is not None:
+            parsed_update_timestamp = parse_utc_timestamp(last_successful_update_at)
+            assert parsed_update_timestamp.tzinfo is not None
+            assert parsed_update_timestamp.utcoffset() == timezone.utc.utcoffset(
+                parsed_update_timestamp
+            )
+
+
+def test_canonical_rpc_fixture_marks_null_aqi_as_degraded_not_healthy():
+    rows = load_fixture()
+    degraded_rows = [row for row in rows if row["aqi_us"] is None]
+
+    assert degraded_rows, "Fixture must keep null aqi_us visible as a degraded contract case"
+    for row in degraded_rows:
+        assert row["reading_timestamp"], "Degraded row still needs traceable measurement timestamp"
+        assert row["city_id"], "Degraded row still needs stable city identity"
+
+
+@pytest.mark.parametrize(
+    "field,bad_value",
+    [
+        ("city_id", None),
+        ("city_id", "9"),
+        ("reading_timestamp", "2026-05-21T16:00:00"),
+        ("reading_timestamp", "not-a-timestamp"),
+    ],
+)
+def test_fixture_contract_examples_would_fail_for_invalid_required_values(field, bad_value):
+    row = dict(load_fixture()[0])
+    row[field] = bad_value
+
+    if field == "city_id":
+        assert not (isinstance(row[field], int) and not isinstance(row[field], bool))
+    elif field == "reading_timestamp":
+        with pytest.raises(ValueError):
+            parse_utc_timestamp(row[field])


### PR DESCRIPTION
## Modo
Dev / QA operativo

## Área tocada
- pipeline: `airquality_pipeline`
- BD MtyRespira: contrato RPC documentado, sin writes live
- UX: impacto indirecto por fail-closed/degradación honesta

## Acción
Implementa la parte local sin red de Story 1.1 para blindar el contrato de `get_latest_air_quality_per_city` con fixture canónico y pruebas de nullability/timestamps.

## Cambios
- Agrega `tests/fixtures/latest_air_quality_rpc_valid.json` con casos canónicos:
  - ciudad sana
  - ciudad con secundarios `null`
  - ciudad con `aqi_us: null` como caso degradado, no lectura sana
- Agrega `tests/test_latest_air_quality_rpc_contract.py` con validaciones puras:
  - columnas canónicas presentes
  - `city_id` numérico/único
  - required fields no nulos
  - campos degradables presentes aunque sean `null`
  - timestamps parseables con UTC explícito
  - ejemplos negativos de required values inválidos
- Agrega `docs/rpc-contract-smoke.md` con forma de ejecución, alcance, reglas y rollback.

## Validación esperada
```bash
pytest tests/test_latest_air_quality_rpc_contract.py
pytest
```

## Riesgos / pendientes
- No modifica runtime productivo.
- No modifica schema/RPC.
- No llama red.
- No usa secretos.
- No escribe en Supabase.
- SQL exacto, grants y nullability runtime real de Supabase siguen `To verify` hasta evidencia live/manual.

## Rollback
Revertir los tres archivos agregados:
- `tests/fixtures/latest_air_quality_rpc_valid.json`
- `tests/test_latest_air_quality_rpc_contract.py`
- `docs/rpc-contract-smoke.md`

Closes #12