### PR TITLE
docs: add provider continuity readiness runbook

### DIFF
--- a/docs/provider-continuity-readiness.md
+++ b/docs/provider-continuity-readiness.md
@@ -1,0 +1,205 @@
+# Provider Continuity Readiness — MtyRespira
+
+Status: Story 1.3 operational docs baseline  
+Scope: `elelier/airquality_pipeline`  
+Reference app repo: `elelier/monterrey-respira` read-only for this PR
+
+## 1. Purpose
+
+This document prepares provider continuity for MtyRespira without changing runtime behavior.
+
+MtyRespira must keep the public experience honest when upstream data acquisition fails. The goal is not to add a new provider or invent fallback readings. The goal is to document the current provider state, classify failures, preserve city-level traceability, and define fail-closed rules that protect the public app.
+
+## 2. Preconditions checked
+
+Story 1.3 was allowed to start because the app repo now has the required canonical basics:
+
+- `AGENTS.md`
+- `docs/PRD.md`
+- `docs/architecture.md`
+- `docs/roadmap.md`
+
+Reference checks from `elelier/monterrey-respira`:
+
+- `AGENTS.md` defines WAQI/AQICN as active when confirmed by pipeline/runtime evidence and AirVisual/IQAir as legacy/fallback when confirmed.
+- `docs/PRD.md` requires provider continuity work to classify upstream failures without unverified fallback providers.
+- `docs/architecture.md` still shows the end-to-end diagram as `AirVisual / IQAir -> airquality_pipeline`, which conflicts with current pipeline evidence and needs a separate app-docs follow-up.
+- `docs/roadmap.md` still says Story 1.2.1 is in progress and Story 1.3 is blocked. PR #24 has been reported merged, so this is drift and needs a separate app-docs follow-up.
+
+This PR does not edit the app repo.
+
+## 3. Provider matrix
+
+| Provider | Runtime role | Selection | Secret | Current state | Allowed use |
+| --- | --- | --- | --- | --- | --- |
+| WAQI/AQICN | Active provider | `AIR_QUALITY_PROVIDER=waqi` | `WAQI_API_TOKEN` | Default provider in `main.py` and GitHub Actions. Uses explicit city-to-station mapping in `waqi_api.py`. | Normal scheduled runs and manual `workflow_dispatch` when the goal is to refresh/readiness-check active production data. |
+| IQAir/AirVisual | Legacy/fallback adapter | `AIR_QUALITY_PROVIDER=airvisual` | `AIRVISUAL_API_KEY` | Kept for explicit fallback only. README documents current key behavior as HTTP 402 Payment Required. | Do not use in normal operations. Only use for a controlled rollback/recovery test if IQAir access is confirmed healthy first. |
+| Any other provider | Not supported | n/a | n/a | No hidden provider exists in current code. | Do not add or simulate a provider in this story. |
+
+Provider selection evidence:
+
+- `DEFAULT_PROVIDER = "waqi"` in `main.py`.
+- GitHub Actions `workflow_dispatch.provider` allows only `waqi` or `airvisual`, defaulting to `waqi`.
+- Scheduled workflow uses `${{ github.event.inputs.provider || 'waqi' }}`.
+- `get_provider()` rejects unsupported provider names.
+
+## 4. WAQI/AQICN continuity model
+
+WAQI continuity depends on a fixed station registry, not an upstream city-list sync.
+
+Current model:
+
+- `waqi_api.EXPECTED_ACTIVE_API_NAMES` lists the expected active municipalities.
+- `waqi_api.WAQI_STATION_BY_API_NAME` maps each supported `api_name` or known alias to a station id.
+- WAQI city sync is intentionally disabled; the pipeline preserves existing Supabase city rows.
+- Runtime still validates `status=ok`, AQI, timestamp, and coordinates before a reading can be inserted.
+
+Expected active coverage:
+
+| API name | WAQI station | Continuity status |
+| --- | --- | --- |
+| Monterrey | `@6492` | mapped and verified by registry |
+| San Nicolas de los Garza | `@6493` | mapped and verified by registry |
+| Guadalupe | `@6494` | mapped and verified by registry |
+| San Pedro Garza Garcia | `@8282` | mapped and verified by registry |
+| Santa Catarina | `@6491` | mapped and verified by registry |
+| General Escobedo | `@6496` | mapped and verified by registry |
+| Garcia | `@6495` | mapped and verified by registry |
+| Ciudad Benito Juarez | `@8113` | mapped and verified by registry |
+| Cadereyta Jimenez | `@10950` | mapped and verified by registry |
+
+## 5. Error taxonomy
+
+| Class | Code / symptom | Source | Fatal to run? | City state | Insert reading? | Public UX implication |
+| --- | --- | --- | --- | --- | --- | --- |
+| Missing WAQI token | `missing_token` or env validation failure for `WAQI_API_TOKEN` | config | Yes | no reliable new status if the run fails before city processing; otherwise `error: missing_token` | No | App keeps last valid RPC data if present; freshness may become stale/old. Do not claim live/current refresh. |
+| Invalid provider selection | unsupported `AIR_QUALITY_PROVIDER` | config | Yes | no city update | No | Operational misconfig. Fix workflow/env, do not change public claims. |
+| HTTP/provider failure | `fetch_failed` | upstream/network/rate/provider | Yes for attempted mapped city if not recovered | `error: fetch_failed` | No | Latest row remains old if one exists; UI must show stale/old/degraded based on `reading_timestamp`. |
+| WAQI status not ok | `waqi_status_not_ok` | upstream/API payload | Yes for attempted mapped city | `error: waqi_status_not_ok` | No | Same as upstream failure. Do not invent AQI. |
+| City without station mapping | `station_not_mapped` | registry/config | Non-fatal operational skip | `error: station_not_mapped` | No | City may be missing/stale; follow station checklist before mapping. |
+| Invalid payload shape | `invalid_payload` | upstream/API payload | Yes for attempted mapped city | `error: invalid_payload` | No | Degraded public state; keep traceability. |
+| Missing AQI | `missing_aqi` or validation `missing_or_invalid_aqi_us` | upstream/API payload | Yes for attempted mapped city | `error: missing_aqi` or `error: validation_failed` | No | AQI must become unavailable/unknown; never convert to AQI `0`. |
+| Missing timestamp | `missing_reading_ts` | upstream/API payload | Yes for attempted mapped city | `error: missing_reading_ts` | No | Cannot trust freshness; UI must degrade. |
+| Missing coordinates | `missing_coordinates` | upstream/API payload | Yes for attempted mapped city | `error: missing_coordinates` | No | No insertion; station cannot be trusted for city placement. |
+| Coordinates outside Nuevo León | `coordinates_out_of_nuevo_leon` or validation latitude/longitude range errors | upstream/API payload or bad mapping | Yes for attempted mapped city | `error: coordinates_out_of_nuevo_leon` or `error: validation_failed` | No | Treat as unsafe mapping; do not change station without evidence. |
+| Temperature invalid | validation `invalid_temperature` / `temperature_out_of_range` | upstream/API payload | Yes for attempted city if temperature is present and invalid | `error: validation_failed` | No | Reject payload; do not silently drop the invalid value after fetch. |
+| Optional weather missing | null temperature/humidity/wind/pressure/weather icon | upstream/API payload | No when mandatory AQI/timestamp/coords are valid | `success` | Yes, with nullable weather fields | App should show `N/D` for missing secondary fields. |
+| Recently updated city | `skipped: up_to_date` decision | pipeline cadence | No | Usually no write for skipped path in current main loop; summary records `up_to_date` | No | Public latest row remains valid if freshness thresholds allow it. |
+
+## 6. Fail-closed rules
+
+The pipeline must fail closed when provider confidence is not enough to create a trustworthy environmental reading.
+
+Required for insert:
+
+- Provider result status is `success`.
+- AQI is present, numeric, and in range `0..500`.
+- `reading_timestamp_iso` is present and parseable by downstream contract.
+- Coordinates are present and inside Nuevo León bounds: lat `25.0..26.5`, lon `-101.0..-99.0`.
+- Optional weather may be null, but present temperature must be within `-50..60` C.
+
+Never do this:
+
+- Do not synthesize AQI, pollutant, weather, coordinates, timestamps, or city mappings.
+- Do not treat missing AQI as `0`.
+- Do not overwrite provider failure with `success` to keep the app green.
+- Do not use AirVisual as normal fallback while the known key/access state is unhealthy.
+- Do not add a provider without a contract, rollout plan, and tests.
+
+## 7. City/station continuity checklist
+
+Use this checklist before changing any WAQI station id:
+
+- [ ] Confirm the city is an active Supabase city and capture its stable `city_id`.
+- [ ] Confirm exact `api_name` used by Supabase.
+- [ ] Confirm a candidate WAQI station page or Cloud API station id.
+- [ ] Run a controlled WAQI fetch with token available.
+- [ ] Confirm payload `status=ok`.
+- [ ] Confirm payload includes AQI.
+- [ ] Confirm payload includes timestamp.
+- [ ] Confirm station coordinates are inside Nuevo León bounds.
+- [ ] Confirm station location reasonably represents the municipality, not only a nearby city.
+- [ ] Add/update tests for the mapping registry and aliases.
+- [ ] Document evidence in code comments or docs.
+
+If any item is uncertain, keep the station unmapped or revert to the last verified mapping.
+
+## 8. Manual validation without destructive writes
+
+Preferred non-destructive checks:
+
+1. Pull request CI: `pytest` only; no Supabase writes.
+2. Local unit tests with mocked provider/Supabase dependencies.
+3. Read-only RPC health workflow:
+   - `workflow_dispatch`
+   - `rpc_contract_health=true`
+   - does not run `main.py`
+   - runs `scripts/rpc_contract_health.py`
+
+Manual provider validation can call WAQI externally, but do not run `main.py --force-update` unless an operator intentionally wants live writes.
+
+## 9. Public UX implications
+
+When provider continuity fails, the app should not claim new data exists.
+
+Expected public behavior is governed by the frontend freshness rules:
+
+- `reading_timestamp` drives environmental freshness.
+- `last_successful_update_at` is pipeline traceability only.
+- Old but valid latest readings may remain visible with stale/old/degraded copy.
+- Missing AQI, missing timestamp, missing latest row, or invalid payload must become unknown/unavailable/degraded.
+- Public copy must avoid “tiempo real”. Prefer “lecturas disponibles”, “medición reportada”, or “actualización por pipeline horario”.
+
+## 10. Rollback procedure
+
+Documentation-only rollback:
+
+1. Revert the docs PR.
+2. Keep runtime unchanged.
+3. Re-open the story with corrected evidence if the rollback removed useful operational guidance.
+
+Runtime rollback if a future provider change breaks continuity:
+
+1. Stop further runtime changes and inspect the latest workflow logs.
+2. Keep `get_latest_air_quality_per_city` unchanged.
+3. Revert the provider/mapping commit that introduced the failure.
+4. Prefer restoring the last verified WAQI mapping over switching providers.
+5. Only use `AIR_QUALITY_PROVIDER=airvisual` after IQAir access is proven healthy; otherwise it is a false fallback.
+6. Validate with `pytest`, then a controlled scheduled/manual run as appropriate.
+7. Validate public app freshness/degradation after the next successful pipeline cycle.
+
+## 11. Follow-up app docs
+
+The app repo has drift that should be corrected separately in `elelier/monterrey-respira`:
+
+### `docs/roadmap.md`
+
+Current drift:
+
+- Story 1.2.1 still says `Estado: en curso`.
+- Story 1.3 still says `Estado: bloqueada hasta merge de Story 1.2.1`.
+
+Suggested patch:
+
+```diff
+- Estado: en curso.
++ Estado: completada por PR #24 — docs: add canonical MtyRespira project docs baseline.
+
+- Estado: bloqueada hasta merge de Story 1.2.1.
++ Estado: desbloqueada tras PR #24; ejecución principal en `elelier/airquality_pipeline`.
+```
+
+### `docs/architecture.md`
+
+Current drift:
+
+- The end-to-end diagram starts with `AirVisual / IQAir`, but pipeline evidence now confirms WAQI/AQICN as active provider and AirVisual as legacy/fallback.
+
+Suggested patch:
+
+```diff
+-AirVisual / IQAir
++WAQI / AQICN (active) or IQAir / AirVisual (legacy/fallback only when explicitly selected and healthy)
+```
+
+Do not make these app-doc updates inside the pipeline PR.

--- a/docs/provider-continuity-runbook.md
+++ b/docs/provider-continuity-runbook.md
@@ -1,0 +1,326 @@
+# Provider Continuity Runbook — MtyRespira
+
+Status: Story 1.3 operational runbook  
+Scope: `elelier/airquality_pipeline`
+
+## 1. When to use this runbook
+
+Use this runbook when:
+
+- The scheduled pipeline fails.
+- Public readings become stale or old.
+- A city stops updating.
+- WAQI/AQICN returns an unexpected response.
+- A maintainer needs to decide whether a manual run is safe.
+
+Do not use this runbook to justify a new provider, schema change, RPC change, or frontend runtime change.
+
+## 2. Fast triage
+
+1. Open the latest GitHub Actions run for `Air Quality Pipeline`.
+2. Confirm whether it was:
+   - scheduled hourly run,
+   - manual `workflow_dispatch`, or
+   - pull request test run.
+3. Check whether the run executed `main.py` or only tests/RPC health.
+4. Open the uploaded `pipeline-log` artifact when available.
+5. Search for these markers:
+   - `[CONFIG] Air quality provider:`
+   - `[WAQI] HTTP GET`
+   - `[SUMMARY] Pipeline operacional`
+   - `City result:`
+   - `[FAIL] Pipeline terminado con error operativo`
+6. Classify the failure using the taxonomy below.
+
+## 3. How to review the latest workflow
+
+Expected healthy scheduled behavior:
+
+- Trigger: schedule `0 * * * *`.
+- Provider: `waqi`.
+- Tests run first with `AIR_QUALITY_PROVIDER=waqi`.
+- Environment is configured from GitHub Actions secrets.
+- `python main.py` runs and writes `pipeline.log`.
+- `pipeline-log` artifact is uploaded even on failure.
+
+Manual checks:
+
+- Use `workflow_dispatch` with `provider=waqi` for normal manual recovery runs.
+- Use `force_update=true` only when you intentionally want to bypass the 59-minute skip decision and write live readings if payloads validate.
+- Use `rpc_contract_health=true` when you need read-only RPC/freshness evidence and do not want to run `main.py`.
+
+## 4. How to read `pipeline.log`
+
+### Provider and configuration
+
+Look for:
+
+```text
+[CONFIG] Air quality provider: waqi
+```
+
+If provider is not `waqi`, confirm the run was intentionally manual. Scheduled production behavior should default to `waqi`.
+
+### City-level decisions
+
+Look for:
+
+```text
+[UPDATE] Ciudad <api_name> necesita actualizacion.
+[SKIP] Ciudad <api_name> no necesita actualizacion.
+[NEEDS_MAPPING] Ciudad <api_name> sin mapping verificado
+[WARN] Update con alertas para <api_name>
+City result: {...}
+```
+
+The `City result` entries are the fastest way to identify affected city, fetch status, error type, insertion result, and validation errors.
+
+### Summary
+
+Look for:
+
+```text
+[SUMMARY] Pipeline operacional
+Provider: waqi
+Ciudades activas: ...
+Updates intentados: ...
+Lecturas insertadas: ...
+Ciudades sin mapping WAQI: ...
+Updates fallidos: ...
+Errores de fetch: ...
+Fallos de validacion: ...
+```
+
+If `updates_attempted > 0` and `readings_inserted == 0`, the run should fail unhealthy. That protects the product from silently accepting a fully failed update cycle.
+
+## 5. Failure classification guide
+
+### Missing or invalid token
+
+Symptoms:
+
+- `Variables de entorno faltantes... WAQI_API_TOKEN`
+- `missing_token`
+- WAQI response indicates invalid key/token through `waqi_status_not_ok`
+
+Meaning:
+
+- Pipeline cannot trust provider access.
+- No AQI should be inserted.
+
+Action:
+
+- Verify GitHub Actions secret presence and spelling.
+- Do not paste tokens into logs, docs, PRs, or issues.
+- Re-run with `provider=waqi` only after secret state is fixed.
+
+### HTTP, rate, or provider failure
+
+Symptoms:
+
+- `fetch_failed`
+- HTTP status in `[WAQI] HTTP GET ... status=<code>`
+- Request timeout or network exception
+- `waqi_status_not_ok`
+
+Meaning:
+
+- Upstream failed or could not be trusted for that city.
+
+Action:
+
+- Check whether failure is isolated to one station or all stations.
+- If all stations fail, assume provider/token/network incident.
+- Do not switch to AirVisual unless IQAir access has been proven healthy.
+- Let public UX degrade through freshness states.
+
+### City without `station_id`
+
+Symptoms:
+
+- `station_not_mapped`
+- `[NEEDS_MAPPING] Ciudad ... sin mapping verificado`
+
+Meaning:
+
+- The city exists in Supabase but has no verified WAQI station mapping.
+- This is non-fatal for the whole run but no reading is inserted for that city.
+
+Action:
+
+- Use the city/station continuity checklist before adding a mapping.
+- Do not map to a nearby station just to make the run green.
+
+### Payload without AQI
+
+Symptoms:
+
+- `missing_aqi`
+- `missing_or_invalid_aqi_us`
+- `aqi_us_out_of_range`
+
+Meaning:
+
+- The payload is not safe as an environmental reading.
+
+Action:
+
+- Do not insert.
+- Do not coerce missing AQI to `0`.
+- Treat as provider/payload issue and let UI show unavailable/degraded.
+
+### Payload without timestamp
+
+Symptoms:
+
+- `missing_reading_ts`
+- `Error: Falta 'reading_timestamp_iso'`
+- invalid `reading_timestamp` in RPC health
+
+Meaning:
+
+- Freshness cannot be trusted.
+
+Action:
+
+- Do not insert.
+- Do not reuse pipeline time as measurement time.
+- Investigate provider payload.
+
+### Coordinates outside Nuevo León
+
+Symptoms:
+
+- `coordinates_out_of_nuevo_leon`
+- `latitude_out_of_range`
+- `longitude_out_of_range`
+
+Meaning:
+
+- Station mapping or upstream payload is unsafe for MtyRespira.
+
+Action:
+
+- Do not insert.
+- Re-check station mapping evidence.
+- Revert any recent station change if applicable.
+
+### Skipped because data is recent
+
+Symptoms:
+
+- `[SKIP] Ciudad ... no necesita actualizacion.`
+- Summary increments `skipped_up_to_date`.
+- City result reason is `up_to_date`.
+
+Meaning:
+
+- The city had a successful update within the configured 59-minute interval.
+
+Action:
+
+- No incident by itself.
+- Use `force_update=true` only for intentional live-write validation.
+
+## 6. When to run `workflow_dispatch` with `provider=waqi`
+
+Safe reasons:
+
+- Recover after a transient WAQI/network failure.
+- Validate provider continuity after secret fix.
+- Confirm station mapping after a reviewed PR.
+- Manually refresh after the schedule was missed.
+
+Recommended settings:
+
+- `provider=waqi`
+- `force_update=false` for normal manual check.
+- `force_update=true` only if you intentionally want live writes for all active cities that pass validation.
+- `rpc_contract_health=false` unless you are intentionally running the read-only health job instead of `main.py`.
+
+## 7. When not to run `provider=airvisual`
+
+Do not run AirVisual when:
+
+- The goal is normal production refresh.
+- WAQI has only a transient failure.
+- IQAir access has not been proven healthy.
+- You are trying to bypass a WAQI mapping/payload validation failure.
+- You do not have evidence that AirVisual returns valid city payloads for the current active cities.
+
+AirVisual is legacy/fallback code. The current README documents IQAir/AirVisual as HTTP 402 Payment Required with the existing key. Running it without fresh evidence is likely to create noise, fail the pipeline, or produce misleading expectations.
+
+## 8. Read-only RPC health check
+
+Use this path when you need public data contract/freshness evidence without pipeline writes.
+
+Manual run:
+
+- Trigger `workflow_dispatch`.
+- Set `rpc_contract_health=true`.
+- Keep provider/force settings irrelevant because `main.py` will not run in the health job.
+
+Expected output:
+
+- `rpc-contract-health-log` artifact.
+- JSON with `status` as `healthy`, `degraded`, `unhealthy`, or `config_error`.
+
+Interpretation:
+
+- `healthy`: contract shape and freshness thresholds pass.
+- `degraded`: shape is okay but one or more readings exceed warning freshness threshold.
+- `unhealthy`: missing city, invalid timestamp, null AQI, stale beyond fail threshold, duplicate city, or missing columns.
+- `config_error`: Supabase env/config/connectivity issue.
+
+This check is read-only but uses Supabase service role inside the pipeline environment. Do not move service role into frontend/app.
+
+## 9. How to communicate degradation
+
+Allowed language:
+
+- “lecturas disponibles”
+- “medición reportada”
+- “actualización por pipeline horario”
+- “la última medición disponible presenta retraso”
+- “sin lectura disponible para esta ciudad”
+
+Do not say:
+
+- “tiempo real”
+- “live”
+- “actualizado al minuto”
+- “dato actual” when `reading_timestamp` is stale/old/unknown
+
+Public communication should distinguish:
+
+- Measurement time: `reading_timestamp`.
+- Pipeline traceability: `last_successful_update_at`.
+- Workflow status: GitHub Actions run health.
+
+## 10. Rollback
+
+For docs-only changes:
+
+```bash
+git revert <docs_commit_sha>
+```
+
+For future runtime provider/mapping changes:
+
+1. Revert the provider/mapping commit.
+2. Keep the RPC unchanged.
+3. Keep Supabase schema unchanged unless a separate rollback plan exists.
+4. Run `pytest`.
+5. Run read-only RPC health if the question is contract/freshness.
+6. Use `workflow_dispatch provider=waqi` only when ready for controlled live writes.
+7. Validate public app behavior after the next healthy reading cycle.
+
+## 11. What not to do
+
+- Do not change station ids during an incident without evidence.
+- Do not add unsupported cities to fix a stale public screen.
+- Do not use Core DB for environmental readings.
+- Do not write directly to Supabase to patch AQI values.
+- Do not alter `get_latest_air_quality_per_city` as part of provider triage.
+- Do not expose or echo secrets.
+- Do not convert missing fields into invented values for UI convenience.


### PR DESCRIPTION
## Resumen

- Adds Story 1.3 provider continuity documentation for MtyRespira.
- Creates `docs/provider-continuity-readiness.md`.
- Creates `docs/provider-continuity-runbook.md`.
- Documentation-only change: no pipeline runtime changes, no provider changes, no Supabase writes, no DDL, no RPC changes, no frontend runtime changes.

## Challenge / por qué Story 1.3 ya puede iniciar tras PR #24

The reference app repo now contains the canonical basics required before starting Story 1.3:

- `AGENTS.md`
- `docs/PRD.md`
- `docs/architecture.md`
- `docs/roadmap.md`

PR #24 was reported merged in `elelier/monterrey-respira`, so the docs baseline gate is no longer a hard stop. However, the app roadmap still appears to contain drift: Story 1.2.1 is still marked `en curso` and Story 1.3 is still marked blocked. This PR documents that as follow-up instead of editing the app repo from the pipeline PR.

## Provider state confirmado

- Active provider: WAQI/AQICN.
- Default provider in pipeline code: `AIR_QUALITY_PROVIDER=waqi`.
- GitHub Actions scheduled/default manual provider: `waqi`.
- Manual `workflow_dispatch` provider choices: `waqi` or `airvisual`.
- Legacy/fallback provider: IQAir/AirVisual.
- Current README documents AirVisual as fallback only and notes the existing key state as HTTP 402 Payment Required.
- No hidden provider was found in the audited pipeline code.

## Documentos creados/actualizados

Created:

- `docs/provider-continuity-readiness.md`
  - provider matrix
  - WAQI continuity model
  - error taxonomy
  - city/station continuity checklist
  - fail-closed rules
  - manual validation without destructive writes
  - rollback procedure
  - public UX implications
  - app-doc follow-up patch suggestions

- `docs/provider-continuity-runbook.md`
  - latest workflow triage
  - how to read `pipeline.log`
  - failure classification guide
  - when to run `workflow_dispatch provider=waqi`
  - when not to run `provider=airvisual`
  - read-only RPC health check guidance
  - degradation communication rules
  - rollback and what-not-to-do

## Impacto por área

### app

No app code or app docs changed in this PR. The app repo was inspected read-only. Follow-up drift is documented for a separate `elelier/monterrey-respira` PR.

### pipeline

Docs only. No changes to `main.py`, `waqi_api.py`, `airvisual_api.py`, `update_city.py`, `sync_cities.py`, `utils.py`, `supabase_client.py`, workflow runtime, station mapping, provider selection, or tests.

### BD MtyRespira

No DB writes. No schema changes. No migrations. No destructive operations.

### Supabase RPC

No RPC changes. `get_latest_air_quality_per_city` remains untouched.

### UX

Documents how public UX should interpret provider failures: stale/old/degraded/unknown states, no invented AQI/weather/timestamps, and no “tiempo real” claim.

### Cloudflare

No Cloudflare changes. Public app hosting is unaffected.

## Validación

- Audited app canonical docs read-only:
  - `AGENTS.md`
  - `docs/PRD.md`
  - `docs/DOCUMENTATION_INDEX.md`
  - `docs/architecture.md`
  - `docs/roadmap.md`
  - `docs/shared-data-contract.md`
  - `docs/freshness-truth-ux.md`
  - `docs/blindaje-y-cambio-de-curso.md`
- Audited pipeline sources read-only:
  - `README.md`
  - `.github/workflows/air-quality-workflow.yml`
  - `main.py`
  - `waqi_api.py`
  - `airvisual_api.py`
  - `update_city.py`
  - `sync_cities.py`
  - `utils.py`
  - `supabase_client.py`
  - existing tests
  - `scripts/rpc_contract_health.py`
- Compared branch against `main`: docs-only, 2 added files.
- No `workflow_dispatch` run.
- No Supabase live writes.
- No local `pytest` executed in this connector session; PR CI should run existing pytest on pull_request.

## Riesgos / pendientes

- The provider docs now depend on the currently audited pipeline behavior. If runtime changes later, these docs must be updated in the same story/PR.
- AirVisual remains legacy/fallback only; using it without proving IQAir access healthy is a false fallback.
- Station mapping changes remain out of scope unless backed by runtime evidence and tests.

## Follow-up requerido en monterrey-respira si aplica

Separate app-docs follow-up is recommended for `elelier/monterrey-respira`:

1. `docs/roadmap.md`
   - Mark Story 1.2.1 as completed by PR #24.
   - Mark Story 1.3 as unblocked / executing in `elelier/airquality_pipeline`.

2. `docs/architecture.md`
   - Update the end-to-end provider diagram from `AirVisual / IQAir` to WAQI/AQICN active plus IQAir/AirVisual legacy/fallback.

This PR intentionally does not edit the app repo.

## Rollback

Docs-only rollback:

```bash
git revert <merge_commit_sha>
```

Runtime rollback is not required because this PR does not modify runtime behavior. If a future provider/runtime change breaks continuity, revert that provider/mapping commit first, keep `get_latest_air_quality_per_city` unchanged, run `pytest`, and use read-only RPC health before any controlled live write run.