### PR TITLE
feat: add weather context dry-run report

### DIFF
--- a/docs/weather-context-dry-run.md
+++ b/docs/weather-context-dry-run.md
@@ -12,7 +12,7 @@ The script creates local evidence only. It does not change `main.py`, `update_ci
 
 ## No-write guarantees
 
-The dry-run uses local JSON/CSV input files and writes only to stdout or to a local report path provided with `--output`.
+The dry-run uses local JSON/CSV input files. Without `--output`, it prints the full JSON report to stdout. With `--output`, it writes the full JSON report to the local report path and prints only a short confirmation.
 
 It does not require:
 
@@ -32,7 +32,7 @@ JSON or CSV is accepted. Required columns/keys:
 
 | Field | Required | Notes |
 | --- | --- | --- |
-| `city_id` | yes | Stable MtyRespira city id. |
+| `city_id` | yes | Stable numeric MtyRespira city id. |
 | `api_name` | yes | City/provider display name used for reporting. |
 | `latitude` | yes | City latitude used for Open-Meteo lookup. |
 | `longitude` | yes | City longitude used for Open-Meteo lookup. |
@@ -56,7 +56,7 @@ JSON or CSV is accepted. Required columns/keys:
 
 | Field | Required | Notes |
 | --- | --- | --- |
-| `city_id` | yes | Must match the active cities file. |
+| `city_id` | yes | Stable numeric id. Must match the active cities file. |
 | `reading_timestamp` | yes | AQI measurement timestamp. UTC is recommended. |
 | `temperature_c` | no | Legacy WAQI weather field for QA delta only. |
 | `humidity_percent` | no | Legacy WAQI weather field for QA delta only. |
@@ -88,7 +88,7 @@ python scripts/weather_backfill_dry_run.py \
   --readings ./local/aqi-candidate-readings.json
 ```
 
-Save a local report file:
+Save a local report file. This writes the full JSON report to disk and prints only a short confirmation to stdout:
 
 ```bash
 python scripts/weather_backfill_dry_run.py \
@@ -127,7 +127,7 @@ The report uses explicit weather field names:
 
 For each candidate AQI row:
 
-1. Match by `city_id`.
+1. Match by numeric `city_id`.
 2. Use the city's `latitude` and `longitude`.
 3. Fetch hourly Open-Meteo weather for the candidate date range.
 4. Choose the weather hour nearest to `reading_timestamp`.
@@ -159,7 +159,7 @@ The dry-run reports the following issues:
 - Missing `reading_timestamp`.
 - Unmatched weather hour.
 - Weather metadata nullability:
-  - if any `weather_*` value is present, `weather_provider` and `weather_timestamp` must exist.
+  - if any `weather_*` value is present, `weather_provider` and `weather_timestamp` must exist in the matched report row.
 - Physical ranges:
   - `weather_temperature_c` hard reject outside `-50..60`.
   - Monterrey QA warning below `-20`.
@@ -171,6 +171,8 @@ The dry-run reports the following issues:
   - temperature delta `>= 8 °C`.
   - humidity delta `>= 25` points.
   - wind is not compared unless a future story explicitly defines unit normalization.
+- Wind unit guardrail:
+  - Open-Meteo km/h values must be reported as `weather_wind_speed_kmh`, never as a `*_ms` weather field.
 
 ## Interpreting results
 
@@ -202,7 +204,8 @@ The tests avoid real network calls by injecting a fake weather fetcher. They cov
 - previous-hour tie breaker.
 - range validation.
 - temperature and humidity deltas against WAQI legacy fields.
-- wind-unit field naming.
+- weather metadata nullability on matched report rows.
+- wind-unit field naming and violation detection.
 - report summary and per-city results.
 - no Supabase client or mutation tokens in the dry-run script.
 

--- a/docs/weather-context-dry-run.md
+++ b/docs/weather-context-dry-run.md
@@ -1,0 +1,216 @@
+# Weather Context Dry-Run — MtyRespira
+
+Status: Story 1.4.4 dry-run evidence tooling  
+Scope: `elelier/airquality_pipeline`  
+Reference app repo: `elelier/monterrey-respira` remains read-only for this story
+
+## Purpose
+
+This document explains how to run `scripts/weather_backfill_dry_run.py` to evaluate Open-Meteo as a separate meteorological context provider for MtyRespira.
+
+The script creates local evidence only. It does not change `main.py`, `update_city.py`, the hourly workflow, the frontend, Supabase schema, RPCs, AQI fields, city geolocation, historical AQI, or the WAQI/AQICN provider contract.
+
+## No-write guarantees
+
+The dry-run uses local JSON/CSV input files and writes only to stdout or to a local report path provided with `--output`.
+
+It does not require:
+
+- Supabase credentials.
+- `SUPABASE_SERVICE_ROLE_KEY`.
+- WAQI credentials.
+- Production database access.
+- DDL or migration permissions.
+
+The script does not import the Supabase client and has a regression test that scans the script source for mutation/client tokens.
+
+## Input files
+
+### Active cities file
+
+JSON or CSV is accepted. Required columns/keys:
+
+| Field | Required | Notes |
+| --- | --- | --- |
+| `city_id` | yes | Stable MtyRespira city id. |
+| `api_name` | yes | City/provider display name used for reporting. |
+| `latitude` | yes | City latitude used for Open-Meteo lookup. |
+| `longitude` | yes | City longitude used for Open-Meteo lookup. |
+
+Example JSON:
+
+```json
+[
+  {
+    "city_id": 9,
+    "api_name": "Monterrey",
+    "latitude": 25.6866,
+    "longitude": -100.3161
+  }
+]
+```
+
+### Candidate AQI readings file
+
+JSON or CSV is accepted. Required columns/keys:
+
+| Field | Required | Notes |
+| --- | --- | --- |
+| `city_id` | yes | Must match the active cities file. |
+| `reading_timestamp` | yes | AQI measurement timestamp. UTC is recommended. |
+| `temperature_c` | no | Legacy WAQI weather field for QA delta only. |
+| `humidity_percent` | no | Legacy WAQI weather field for QA delta only. |
+| `wind_speed_ms` | no | Legacy field. The dry-run does not store Open-Meteo km/h here. |
+| `wind_direction_deg` | no | Legacy WAQI weather field for QA context. |
+
+Example JSON:
+
+```json
+[
+  {
+    "city_id": 9,
+    "reading_timestamp": "2026-05-24T18:00:00Z",
+    "temperature_c": 15.5,
+    "humidity_percent": 40,
+    "wind_speed_ms": 2.5,
+    "wind_direction_deg": 90
+  }
+]
+```
+
+## How to run
+
+Default stdout JSON report:
+
+```bash
+python scripts/weather_backfill_dry_run.py \
+  --cities ./local/active-cities.json \
+  --readings ./local/aqi-candidate-readings.json
+```
+
+Save a local report file:
+
+```bash
+python scripts/weather_backfill_dry_run.py \
+  --cities ./local/active-cities.json \
+  --readings ./local/aqi-candidate-readings.json \
+  --window-days 60 \
+  --output reports/weather-backfill-dry-run.json
+```
+
+## Open-Meteo request contract
+
+The script calls the Open-Meteo Historical Weather API by city coordinates and candidate reading dates.
+
+It requests:
+
+```text
+hourly=temperature_2m,relative_humidity_2m,wind_speed_10m,wind_direction_10m,wind_gusts_10m
+timezone=UTC
+wind_speed_unit=kmh
+temperature_unit=celsius
+```
+
+The report uses explicit weather field names:
+
+- `weather_temperature_c`
+- `weather_humidity_percent`
+- `weather_wind_speed_kmh`
+- `weather_wind_direction_deg`
+- `weather_wind_gust_kmh`
+- `weather_provider`
+- `weather_timestamp`
+
+`reading_timestamp` is never changed or reused as the weather timestamp.
+
+## Matching logic
+
+For each candidate AQI row:
+
+1. Match by `city_id`.
+2. Use the city's `latitude` and `longitude`.
+3. Fetch hourly Open-Meteo weather for the candidate date range.
+4. Choose the weather hour nearest to `reading_timestamp`.
+5. Accept the match only when the absolute delta is `<= 30` minutes.
+6. If there is an exact tie, choose the previous hour.
+7. Leave unmatched rows in the report as validation issues.
+
+## Report format
+
+The JSON report contains:
+
+| Field | Meaning |
+| --- | --- |
+| `mode` | Always `dry_run`. |
+| `provider` | Always `open-meteo`. |
+| `window_days` | Evidence window label from CLI input. |
+| `generated_at` | UTC report generation timestamp. |
+| `summary` | Aggregate counts and validation counts. |
+| `city_results` | Per-city target rows, matched rows, max alignment delta, sampled matches, and range summaries. |
+| `validation_issues` | Missing input, unmatched hour, range, delta, and provider fetch issues. |
+| `unit_contract` | Explicit wind-unit guardrail for `weather_wind_speed_kmh`. |
+
+## Validation rules
+
+The dry-run reports the following issues:
+
+- Expected row count vs matched count.
+- Missing coordinates.
+- Missing `reading_timestamp`.
+- Unmatched weather hour.
+- Weather metadata nullability:
+  - if any `weather_*` value is present, `weather_provider` and `weather_timestamp` must exist.
+- Physical ranges:
+  - `weather_temperature_c` hard reject outside `-50..60`.
+  - Monterrey QA warning below `-20`.
+  - `weather_humidity_percent` must be `0..100`.
+  - `weather_wind_speed_kmh` must be `>= 0`; warning above `160`.
+  - `weather_wind_gust_kmh` must be `>= 0`; warning above `220`.
+  - `weather_wind_direction_deg` must be `0..360`.
+- Delta against WAQI legacy fields:
+  - temperature delta `>= 8 °C`.
+  - humidity delta `>= 25` points.
+  - wind is not compared unless a future story explicitly defines unit normalization.
+
+## Interpreting results
+
+Use the report to answer these questions before any contract or migration story:
+
+- Are all active cities present with coordinates?
+- Do all candidate AQI rows have a valid timestamp?
+- Does Open-Meteo provide hourly data for the candidate windows?
+- Are matched rows close enough to AQI readings under the `<= 30 min` rule?
+- Are physical ranges reasonable for Monterrey and the metropolitan area?
+- Do deltas against WAQI legacy weather fields confirm the need for a separate weather provider?
+- Does the wind unit remain explicitly `weather_wind_speed_kmh`?
+
+Warnings do not invalidate AQI. They help decide whether weather context should be stored, how it should be named, and how UI copy should explain source/timestamp.
+
+## Tests
+
+Run:
+
+```bash
+pytest tests/test_weather_backfill_dry_run.py
+pytest
+```
+
+The tests avoid real network calls by injecting a fake weather fetcher. They cover:
+
+- nearest-hour matching.
+- threshold rejection above 30 minutes.
+- previous-hour tie breaker.
+- range validation.
+- temperature and humidity deltas against WAQI legacy fields.
+- wind-unit field naming.
+- report summary and per-city results.
+- no Supabase client or mutation tokens in the dry-run script.
+
+## Next steps
+
+Story 1.4.5 should use dry-run evidence to decide the production weather contract:
+
+- additive weather columns on `air_quality_readings`, or
+- separate `weather_context_readings` table.
+
+That future story must still avoid live apply unless explicitly approved. It should preserve AQI, main pollutant, historical AQI, geolocation, `reading_timestamp`, and the public RPC contract until a coordinated migration/RPC/app rollout exists.

--- a/scripts/weather_backfill_dry_run.py
+++ b/scripts/weather_backfill_dry_run.py
@@ -1,0 +1,668 @@
+"""Dry-run Open-Meteo weather context report for MtyRespira.
+
+This CLI evaluates how candidate AQI readings would match coordinate-based
+Open-Meteo hourly weather context. It reads local JSON/CSV exports only and
+produces a local report. It does not import Supabase clients or mutate any
+database state.
+"""
+
+from __future__ import annotations
+
+import argparse
+import csv
+import json
+import sys
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Callable
+
+import requests
+
+OPEN_METEO_ARCHIVE_URL = "https://archive-api.open-meteo.com/v1/archive"
+PROVIDER = "open-meteo"
+MODE = "dry_run"
+MATCH_THRESHOLD_MINUTES = 30.0
+TEMPERATURE_DELTA_WARNING_C = 8.0
+HUMIDITY_DELTA_WARNING_POINTS = 25.0
+HOURLY_VARIABLES = (
+    "temperature_2m",
+    "relative_humidity_2m",
+    "wind_speed_10m",
+    "wind_direction_10m",
+    "wind_gusts_10m",
+)
+
+
+@dataclass(frozen=True)
+class CityInput:
+    city_id: str
+    api_name: str
+    latitude: float | None
+    longitude: float | None
+
+
+@dataclass(frozen=True)
+class AqiReadingInput:
+    city_id: str
+    reading_timestamp: datetime | None
+    temperature_c: float | None = None
+    humidity_percent: float | None = None
+    wind_speed_ms: float | None = None
+    wind_direction_deg: float | None = None
+
+
+@dataclass(frozen=True)
+class WeatherHour:
+    timestamp: datetime
+    temperature_c: float | None
+    humidity_percent: float | None
+    wind_speed_kmh: float | None
+    wind_direction_deg: float | None
+    wind_gust_kmh: float | None
+
+
+def parse_utc_timestamp(value: Any) -> datetime | None:
+    if value is None:
+        return None
+    if not isinstance(value, str) or not value.strip():
+        return None
+    normalized = value.strip().replace("Z", "+00:00")
+    parsed = datetime.fromisoformat(normalized)
+    if parsed.tzinfo is None:
+        parsed = parsed.replace(tzinfo=timezone.utc)
+    return parsed.astimezone(timezone.utc)
+
+
+def parse_optional_float(value: Any) -> float | None:
+    if value is None or value == "":
+        return None
+    try:
+        return float(value)
+    except (TypeError, ValueError):
+        return None
+
+
+def _read_records(path: Path) -> list[dict[str, Any]]:
+    suffix = path.suffix.lower()
+    if suffix == ".json":
+        payload = json.loads(path.read_text(encoding="utf-8"))
+        if isinstance(payload, list):
+            return [dict(item) for item in payload if isinstance(item, dict)]
+        if isinstance(payload, dict):
+            for key in ("rows", "data", "cities", "readings"):
+                value = payload.get(key)
+                if isinstance(value, list):
+                    return [dict(item) for item in value if isinstance(item, dict)]
+        raise ValueError(f"{path} must contain an array or an object with rows/data")
+    if suffix == ".csv":
+        with path.open(newline="", encoding="utf-8") as handle:
+            return [dict(row) for row in csv.DictReader(handle)]
+    raise ValueError(f"Unsupported input format for {path}; use JSON or CSV")
+
+
+def load_cities(path: Path) -> list[CityInput]:
+    cities: list[CityInput] = []
+    for row in _read_records(path):
+        cities.append(
+            CityInput(
+                city_id=str(row.get("city_id", "")).strip(),
+                api_name=str(row.get("api_name", "")).strip(),
+                latitude=parse_optional_float(row.get("latitude")),
+                longitude=parse_optional_float(row.get("longitude")),
+            )
+        )
+    return cities
+
+
+def load_readings(path: Path) -> list[AqiReadingInput]:
+    readings: list[AqiReadingInput] = []
+    for row in _read_records(path):
+        readings.append(
+            AqiReadingInput(
+                city_id=str(row.get("city_id", "")).strip(),
+                reading_timestamp=parse_utc_timestamp(row.get("reading_timestamp")),
+                temperature_c=parse_optional_float(row.get("temperature_c")),
+                humidity_percent=parse_optional_float(row.get("humidity_percent")),
+                wind_speed_ms=parse_optional_float(row.get("wind_speed_ms")),
+                wind_direction_deg=parse_optional_float(row.get("wind_direction_deg")),
+            )
+        )
+    return readings
+
+
+def build_open_meteo_params(city: CityInput, start_date: str, end_date: str) -> dict[str, Any]:
+    return {
+        "latitude": city.latitude,
+        "longitude": city.longitude,
+        "start_date": start_date,
+        "end_date": end_date,
+        "hourly": ",".join(HOURLY_VARIABLES),
+        "timezone": "UTC",
+        "wind_speed_unit": "kmh",
+        "temperature_unit": "celsius",
+    }
+
+
+def fetch_open_meteo_hours(
+    city: CityInput,
+    *,
+    start_date: str,
+    end_date: str,
+    timeout_seconds: int = 45,
+) -> list[WeatherHour]:
+    params = build_open_meteo_params(city, start_date, end_date)
+    response = requests.get(OPEN_METEO_ARCHIVE_URL, params=params, timeout=timeout_seconds)
+    response.raise_for_status()
+    return parse_open_meteo_hours(response.json())
+
+
+def parse_open_meteo_hours(payload: dict[str, Any]) -> list[WeatherHour]:
+    hourly = payload.get("hourly")
+    if not isinstance(hourly, dict):
+        return []
+
+    times = hourly.get("time") or []
+    temperatures = hourly.get("temperature_2m") or []
+    humidities = hourly.get("relative_humidity_2m") or []
+    wind_speeds = hourly.get("wind_speed_10m") or []
+    wind_directions = hourly.get("wind_direction_10m") or []
+    wind_gusts = hourly.get("wind_gusts_10m") or []
+
+    weather_hours: list[WeatherHour] = []
+    for index, raw_time in enumerate(times):
+        timestamp = parse_utc_timestamp(str(raw_time))
+        if timestamp is None:
+            continue
+        weather_hours.append(
+            WeatherHour(
+                timestamp=timestamp,
+                temperature_c=_list_float(temperatures, index),
+                humidity_percent=_list_float(humidities, index),
+                wind_speed_kmh=_list_float(wind_speeds, index),
+                wind_direction_deg=_list_float(wind_directions, index),
+                wind_gust_kmh=_list_float(wind_gusts, index),
+            )
+        )
+    return weather_hours
+
+
+def _list_float(values: Any, index: int) -> float | None:
+    if not isinstance(values, list) or index >= len(values):
+        return None
+    return parse_optional_float(values[index])
+
+
+def find_nearest_weather_hour(
+    reading_timestamp: datetime,
+    weather_hours: list[WeatherHour],
+    *,
+    threshold_minutes: float = MATCH_THRESHOLD_MINUTES,
+) -> tuple[WeatherHour | None, float | None]:
+    if not weather_hours:
+        return None, None
+
+    best = min(
+        weather_hours,
+        key=lambda hour: (
+            abs((hour.timestamp - reading_timestamp).total_seconds()),
+            hour.timestamp > reading_timestamp,
+        ),
+    )
+    delta_minutes = abs((best.timestamp - reading_timestamp).total_seconds()) / 60
+    if delta_minutes > threshold_minutes:
+        return None, delta_minutes
+    return best, delta_minutes
+
+
+def validate_weather_row(
+    *,
+    city: CityInput,
+    reading: AqiReadingInput,
+    weather_hour: WeatherHour,
+) -> list[dict[str, Any]]:
+    issues: list[dict[str, Any]] = []
+    selected = {
+        "weather_temperature_c": weather_hour.temperature_c,
+        "weather_humidity_percent": weather_hour.humidity_percent,
+        "weather_wind_speed_kmh": weather_hour.wind_speed_kmh,
+        "weather_wind_direction_deg": weather_hour.wind_direction_deg,
+        "weather_wind_gust_kmh": weather_hour.wind_gust_kmh,
+    }
+    if any(value is not None for value in selected.values()):
+        if not PROVIDER or weather_hour.timestamp is None:
+            issues.append(
+                _issue(
+                    "weather_nullability",
+                    "error",
+                    city,
+                    reading,
+                    "Weather source metadata missing",
+                )
+            )
+
+    temperature = weather_hour.temperature_c
+    if temperature is not None:
+        if temperature < -50 or temperature > 60:
+            issues.append(
+                _issue(
+                    "weather_temperature_out_of_hard_range",
+                    "error",
+                    city,
+                    reading,
+                    "Temperature outside -50..60 C",
+                )
+            )
+        elif temperature < -20:
+            issues.append(
+                _issue(
+                    "weather_temperature_monterrey_low_warning",
+                    "warning",
+                    city,
+                    reading,
+                    "Temperature below Monterrey QA warning range",
+                )
+            )
+        if (
+            reading.temperature_c is not None
+            and abs(temperature - reading.temperature_c) >= TEMPERATURE_DELTA_WARNING_C
+        ):
+            issues.append(
+                _issue(
+                    "large_temperature_delta_vs_waqi",
+                    "warning",
+                    city,
+                    reading,
+                    "Temperature delta vs WAQI legacy field >= 8 C",
+                )
+            )
+
+    humidity = weather_hour.humidity_percent
+    if humidity is not None:
+        if humidity < 0 or humidity > 100:
+            issues.append(
+                _issue(
+                    "weather_humidity_out_of_range",
+                    "error",
+                    city,
+                    reading,
+                    "Humidity outside 0..100 percent",
+                )
+            )
+        if (
+            reading.humidity_percent is not None
+            and abs(humidity - reading.humidity_percent) >= HUMIDITY_DELTA_WARNING_POINTS
+        ):
+            issues.append(
+                _issue(
+                    "large_humidity_delta_vs_waqi",
+                    "warning",
+                    city,
+                    reading,
+                    "Humidity delta vs WAQI legacy field >= 25 points",
+                )
+            )
+
+    wind_speed = weather_hour.wind_speed_kmh
+    if wind_speed is not None:
+        if wind_speed < 0:
+            issues.append(
+                _issue(
+                    "weather_wind_speed_negative",
+                    "error",
+                    city,
+                    reading,
+                    "Wind speed is negative",
+                )
+            )
+        elif wind_speed > 160:
+            issues.append(
+                _issue(
+                    "weather_wind_speed_high_warning",
+                    "warning",
+                    city,
+                    reading,
+                    "Wind speed above 160 km/h",
+                )
+            )
+
+    wind_gust = weather_hour.wind_gust_kmh
+    if wind_gust is not None:
+        if wind_gust < 0:
+            issues.append(
+                _issue(
+                    "weather_wind_gust_negative",
+                    "error",
+                    city,
+                    reading,
+                    "Wind gust is negative",
+                )
+            )
+        elif wind_gust > 220:
+            issues.append(
+                _issue(
+                    "weather_wind_gust_high_warning",
+                    "warning",
+                    city,
+                    reading,
+                    "Wind gust above 220 km/h",
+                )
+            )
+
+    wind_direction = weather_hour.wind_direction_deg
+    if wind_direction is not None and (wind_direction < 0 or wind_direction > 360):
+        issues.append(
+            _issue(
+                "weather_wind_direction_out_of_range",
+                "error",
+                city,
+                reading,
+                "Wind direction outside 0..360 degrees",
+            )
+        )
+
+    return issues
+
+
+def _issue(
+    code: str,
+    severity: str,
+    city: CityInput,
+    reading: AqiReadingInput,
+    message: str,
+    extra: dict[str, Any] | None = None,
+) -> dict[str, Any]:
+    payload: dict[str, Any] = {
+        "code": code,
+        "severity": severity,
+        "city_id": city.city_id,
+        "api_name": city.api_name,
+        "reading_timestamp": (
+            reading.reading_timestamp.isoformat().replace("+00:00", "Z")
+            if reading.reading_timestamp
+            else None
+        ),
+        "message": message,
+    }
+    if extra:
+        payload.update(extra)
+    return payload
+
+
+def build_dry_run_report(
+    *,
+    cities: list[CityInput],
+    readings: list[AqiReadingInput],
+    weather_fetcher: Callable[[CityInput, str, str], list[WeatherHour]] | None = None,
+    window_days: int = 60,
+    generated_at: datetime | None = None,
+) -> dict[str, Any]:
+    fetcher = weather_fetcher or _default_weather_fetcher
+    generated = generated_at or datetime.now(timezone.utc)
+    cities_by_id = {city.city_id: city for city in cities}
+    readings_by_city: dict[str, list[AqiReadingInput]] = {}
+    validation_issues: list[dict[str, Any]] = []
+    city_results: list[dict[str, Any]] = []
+
+    for reading in readings:
+        readings_by_city.setdefault(reading.city_id, []).append(reading)
+
+    total_matched = 0
+    total_unmatched = 0
+    null_weather_rows = 0
+    large_delta_rows = 0
+
+    for city in cities:
+        city_readings = readings_by_city.get(city.city_id, [])
+        city_issues: list[dict[str, Any]] = []
+        matched_rows: list[dict[str, Any]] = []
+        max_delta_minutes: float | None = None
+        weather_hours: list[WeatherHour] = []
+
+        if city.latitude is None or city.longitude is None:
+            city_issues.append(
+                _issue(
+                    "missing_coordinates",
+                    "error",
+                    city,
+                    _empty_reading(city),
+                    "City is missing latitude or longitude",
+                )
+            )
+        else:
+            dated_readings = [
+                reading for reading in city_readings if reading.reading_timestamp is not None
+            ]
+            if dated_readings:
+                start_date = min(
+                    reading.reading_timestamp
+                    for reading in dated_readings
+                    if reading.reading_timestamp
+                ).date().isoformat()
+                end_date = max(
+                    reading.reading_timestamp
+                    for reading in dated_readings
+                    if reading.reading_timestamp
+                ).date().isoformat()
+                try:
+                    weather_hours = fetcher(city, start_date, end_date)
+                except Exception as exc:  # noqa: BLE001 - keep provider failure context.
+                    city_issues.append(
+                        _issue("open_meteo_fetch_failed", "error", city, dated_readings[0], str(exc))
+                    )
+
+        for reading in city_readings:
+            if reading.reading_timestamp is None:
+                issue = _issue(
+                    "missing_reading_timestamp",
+                    "error",
+                    city,
+                    reading,
+                    "AQI candidate row is missing reading_timestamp",
+                )
+                city_issues.append(issue)
+                total_unmatched += 1
+                continue
+
+            match, delta_minutes = find_nearest_weather_hour(reading.reading_timestamp, weather_hours)
+            if match is None:
+                issue = _issue(
+                    "unmatched_weather_hour",
+                    "warning",
+                    city,
+                    reading,
+                    "No Open-Meteo hourly weather bucket within threshold",
+                    {"nearest_delta_minutes": delta_minutes},
+                )
+                city_issues.append(issue)
+                total_unmatched += 1
+                continue
+
+            weather_issues = validate_weather_row(city=city, reading=reading, weather_hour=match)
+            city_issues.extend(weather_issues)
+            if any(issue["code"].startswith("large_") for issue in weather_issues):
+                large_delta_rows += 1
+            if all(
+                value is None
+                for value in (
+                    match.temperature_c,
+                    match.humidity_percent,
+                    match.wind_speed_kmh,
+                    match.wind_direction_deg,
+                    match.wind_gust_kmh,
+                )
+            ):
+                null_weather_rows += 1
+
+            max_delta_minutes = (
+                delta_minutes
+                if max_delta_minutes is None
+                else max(max_delta_minutes, delta_minutes or 0)
+            )
+            matched_rows.append(_matched_row(reading, match, delta_minutes))
+            total_matched += 1
+
+        validation_issues.extend(city_issues)
+        city_results.append(
+            _city_result(
+                city=city,
+                target_rows=len(city_readings),
+                matched_rows=matched_rows,
+                max_delta_minutes=max_delta_minutes,
+                issues=city_issues,
+            )
+        )
+
+    unknown_city_readings = [reading for reading in readings if reading.city_id not in cities_by_id]
+    for reading in unknown_city_readings:
+        placeholder_city = CityInput(reading.city_id, "", None, None)
+        validation_issues.append(
+            _issue(
+                "unknown_city_id",
+                "error",
+                placeholder_city,
+                reading,
+                "Reading city_id not found in cities input",
+            )
+        )
+        total_unmatched += 1
+
+    range_violations = sum(
+        1 for issue in validation_issues if "range" in issue["code"] or "negative" in issue["code"]
+    )
+    unit_violations = sum(
+        1 for issue in validation_issues if issue["code"] == "weather_wind_unit_violation"
+    )
+
+    return {
+        "mode": MODE,
+        "provider": PROVIDER,
+        "window_days": window_days,
+        "generated_at": generated.astimezone(timezone.utc)
+        .isoformat()
+        .replace("+00:00", "Z"),
+        "summary": {
+            "active_cities": len(cities),
+            "target_aqi_rows": len(readings),
+            "matched_rows": total_matched,
+            "unmatched_rows": total_unmatched,
+            "null_weather_rows": null_weather_rows,
+            "unit_violations": unit_violations,
+            "range_violations": range_violations,
+            "large_delta_vs_waqi_rows": large_delta_rows,
+            "validation_issue_count": len(validation_issues),
+        },
+        "city_results": city_results,
+        "validation_issues": validation_issues,
+        "unit_contract": {
+            "weather_wind_speed_field": "weather_wind_speed_kmh",
+            "open_meteo_wind_speed_unit": "kmh",
+            "legacy_wind_speed_field": "wind_speed_ms",
+            "legacy_wind_compare_rule": "compare only after explicit m/s to km/h normalization",
+        },
+    }
+
+
+def _default_weather_fetcher(city: CityInput, start_date: str, end_date: str) -> list[WeatherHour]:
+    return fetch_open_meteo_hours(city, start_date=start_date, end_date=end_date)
+
+
+def _empty_reading(city: CityInput) -> AqiReadingInput:
+    return AqiReadingInput(city_id=city.city_id, reading_timestamp=None)
+
+
+def _matched_row(
+    reading: AqiReadingInput,
+    weather_hour: WeatherHour,
+    delta_minutes: float | None,
+) -> dict[str, Any]:
+    return {
+        "reading_timestamp": (
+            reading.reading_timestamp.isoformat().replace("+00:00", "Z")
+            if reading.reading_timestamp
+            else None
+        ),
+        "weather_timestamp": weather_hour.timestamp.isoformat().replace("+00:00", "Z"),
+        "alignment_delta_minutes": round(delta_minutes or 0, 3),
+        "weather_provider": PROVIDER,
+        "weather_temperature_c": weather_hour.temperature_c,
+        "weather_humidity_percent": weather_hour.humidity_percent,
+        "weather_wind_speed_kmh": weather_hour.wind_speed_kmh,
+        "weather_wind_direction_deg": weather_hour.wind_direction_deg,
+        "weather_wind_gust_kmh": weather_hour.wind_gust_kmh,
+    }
+
+
+def _city_result(
+    *,
+    city: CityInput,
+    target_rows: int,
+    matched_rows: list[dict[str, Any]],
+    max_delta_minutes: float | None,
+    issues: list[dict[str, Any]],
+) -> dict[str, Any]:
+    temperatures = [
+        row["weather_temperature_c"]
+        for row in matched_rows
+        if row["weather_temperature_c"] is not None
+    ]
+    wind_speeds = [
+        row["weather_wind_speed_kmh"]
+        for row in matched_rows
+        if row["weather_wind_speed_kmh"] is not None
+    ]
+    humidities = [
+        row["weather_humidity_percent"]
+        for row in matched_rows
+        if row["weather_humidity_percent"] is not None
+    ]
+    return {
+        "city_id": city.city_id,
+        "api_name": city.api_name,
+        "target_rows": target_rows,
+        "matched_rows": len(matched_rows),
+        "unmatched_rows": target_rows - len(matched_rows),
+        "max_alignment_delta_minutes": (
+            round(max_delta_minutes, 3) if max_delta_minutes is not None else None
+        ),
+        "temperature_min_c": min(temperatures) if temperatures else None,
+        "temperature_max_c": max(temperatures) if temperatures else None,
+        "humidity_min_percent": min(humidities) if humidities else None,
+        "humidity_max_percent": max(humidities) if humidities else None,
+        "wind_speed_max_kmh": max(wind_speeds) if wind_speeds else None,
+        "issue_count": len(issues),
+        "sample_matches": matched_rows[:5],
+    }
+
+
+def write_report(report: dict[str, Any], output_path: Path | None) -> None:
+    serialized = json.dumps(report, indent=2, sort_keys=True)
+    if output_path is None:
+        print(serialized)
+        return
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    output_path.write_text(serialized + "\n", encoding="utf-8")
+    print(serialized)
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(
+        description="Generate a dry-run Open-Meteo weather context evidence report."
+    )
+    parser.add_argument("--cities", required=True, type=Path, help="Local JSON/CSV active cities export")
+    parser.add_argument(
+        "--readings", required=True, type=Path, help="Local JSON/CSV AQI candidate readings export"
+    )
+    parser.add_argument("--window-days", type=int, default=60, help="Evidence window label")
+    parser.add_argument("--output", type=Path, help="Optional local report path")
+    args = parser.parse_args(argv)
+
+    cities = load_cities(args.cities)
+    readings = load_readings(args.readings)
+    report = build_dry_run_report(cities=cities, readings=readings, window_days=args.window_days)
+    write_report(report, args.output)
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/weather_backfill_dry_run.py
+++ b/scripts/weather_backfill_dry_run.py
@@ -385,7 +385,8 @@ def _issue(
         "message": message,
     }
     if extra:
-        payload.update(extra)
+        for key, value in extra.items():
+            payload[key] = value
     return payload
 
 

--- a/scripts/weather_backfill_dry_run.py
+++ b/scripts/weather_backfill_dry_run.py
@@ -32,11 +32,18 @@ HOURLY_VARIABLES = (
     "wind_direction_10m",
     "wind_gusts_10m",
 )
+WEATHER_VALUE_FIELDS = (
+    "weather_temperature_c",
+    "weather_humidity_percent",
+    "weather_wind_speed_kmh",
+    "weather_wind_direction_deg",
+    "weather_wind_gust_kmh",
+)
 
 
 @dataclass(frozen=True)
 class CityInput:
-    city_id: str
+    city_id: int
     api_name: str
     latitude: float | None
     longitude: float | None
@@ -44,7 +51,7 @@ class CityInput:
 
 @dataclass(frozen=True)
 class AqiReadingInput:
-    city_id: str
+    city_id: int
     reading_timestamp: datetime | None
     temperature_c: float | None = None
     humidity_percent: float | None = None
@@ -74,6 +81,18 @@ def parse_utc_timestamp(value: Any) -> datetime | None:
     return parsed.astimezone(timezone.utc)
 
 
+def parse_required_int(value: Any, field_name: str) -> int:
+    if value is None or value == "":
+        raise ValueError(f"{field_name} is required and must be an integer")
+    try:
+        parsed = int(value)
+    except (TypeError, ValueError) as exc:
+        raise ValueError(f"{field_name} must be an integer") from exc
+    if isinstance(value, float) and not value.is_integer():
+        raise ValueError(f"{field_name} must be an integer")
+    return parsed
+
+
 def parse_optional_float(value: Any) -> float | None:
     if value is None or value == "":
         return None
@@ -94,7 +113,9 @@ def _read_records(path: Path) -> list[dict[str, Any]]:
                 value = payload.get(key)
                 if isinstance(value, list):
                     return [dict(item) for item in value if isinstance(item, dict)]
-        raise ValueError(f"{path} must contain an array or an object with rows/data")
+        raise ValueError(
+            f"{path} must contain an array or an object with rows/data/cities/readings"
+        )
     if suffix == ".csv":
         with path.open(newline="", encoding="utf-8") as handle:
             return [dict(row) for row in csv.DictReader(handle)]
@@ -106,7 +127,7 @@ def load_cities(path: Path) -> list[CityInput]:
     for row in _read_records(path):
         cities.append(
             CityInput(
-                city_id=str(row.get("city_id", "")).strip(),
+                city_id=parse_required_int(row.get("city_id"), "city_id"),
                 api_name=str(row.get("api_name", "")).strip(),
                 latitude=parse_optional_float(row.get("latitude")),
                 longitude=parse_optional_float(row.get("longitude")),
@@ -120,7 +141,7 @@ def load_readings(path: Path) -> list[AqiReadingInput]:
     for row in _read_records(path):
         readings.append(
             AqiReadingInput(
-                city_id=str(row.get("city_id", "")).strip(),
+                city_id=parse_required_int(row.get("city_id"), "city_id"),
                 reading_timestamp=parse_utc_timestamp(row.get("reading_timestamp")),
                 temperature_c=parse_optional_float(row.get("temperature_c")),
                 humidity_percent=parse_optional_float(row.get("humidity_percent")),
@@ -222,24 +243,6 @@ def validate_weather_row(
     weather_hour: WeatherHour,
 ) -> list[dict[str, Any]]:
     issues: list[dict[str, Any]] = []
-    selected = {
-        "weather_temperature_c": weather_hour.temperature_c,
-        "weather_humidity_percent": weather_hour.humidity_percent,
-        "weather_wind_speed_kmh": weather_hour.wind_speed_kmh,
-        "weather_wind_direction_deg": weather_hour.wind_direction_deg,
-        "weather_wind_gust_kmh": weather_hour.wind_gust_kmh,
-    }
-    if any(value is not None for value in selected.values()):
-        if not PROVIDER or weather_hour.timestamp is None:
-            issues.append(
-                _issue(
-                    "weather_nullability",
-                    "error",
-                    city,
-                    reading,
-                    "Weather source metadata missing",
-                )
-            )
 
     temperature = weather_hour.temperature_c
     if temperature is not None:
@@ -364,6 +367,40 @@ def validate_weather_row(
     return issues
 
 
+def validate_matched_report_row(
+    *,
+    city: CityInput,
+    reading: AqiReadingInput,
+    row: dict[str, Any],
+) -> list[dict[str, Any]]:
+    issues: list[dict[str, Any]] = []
+    has_weather_value = any(row.get(field) is not None for field in WEATHER_VALUE_FIELDS)
+
+    if has_weather_value and (not row.get("weather_provider") or not row.get("weather_timestamp")):
+        issues.append(
+            _issue(
+                "weather_nullability",
+                "error",
+                city,
+                reading,
+                "weather_provider and weather_timestamp are required when weather_* values exist",
+            )
+        )
+
+    if "weather_wind_speed_ms" in row:
+        issues.append(
+            _issue(
+                "weather_wind_unit_violation",
+                "error",
+                city,
+                reading,
+                "Open-Meteo km/h values must not be reported in *_ms fields",
+            )
+        )
+
+    return issues
+
+
 def _issue(
     code: str,
     severity: str,
@@ -401,7 +438,7 @@ def build_dry_run_report(
     fetcher = weather_fetcher or _default_weather_fetcher
     generated = generated_at or datetime.now(timezone.utc)
     cities_by_id = {city.city_id: city for city in cities}
-    readings_by_city: dict[str, list[AqiReadingInput]] = {}
+    readings_by_city: dict[int, list[AqiReadingInput]] = {}
     validation_issues: list[dict[str, Any]] = []
     city_results: list[dict[str, Any]] = []
 
@@ -480,6 +517,10 @@ def build_dry_run_report(
                 continue
 
             weather_issues = validate_weather_row(city=city, reading=reading, weather_hour=match)
+            matched_row = _matched_row(reading, match, delta_minutes)
+            weather_issues.extend(
+                validate_matched_report_row(city=city, reading=reading, row=matched_row)
+            )
             city_issues.extend(weather_issues)
             if any(issue["code"].startswith("large_") for issue in weather_issues):
                 large_delta_rows += 1
@@ -500,7 +541,7 @@ def build_dry_run_report(
                 if max_delta_minutes is None
                 else max(max_delta_minutes, delta_minutes or 0)
             )
-            matched_rows.append(_matched_row(reading, match, delta_minutes))
+            matched_rows.append(matched_row)
             total_matched += 1
 
         validation_issues.extend(city_issues)
@@ -643,7 +684,7 @@ def write_report(report: dict[str, Any], output_path: Path | None) -> None:
         return
     output_path.parent.mkdir(parents=True, exist_ok=True)
     output_path.write_text(serialized + "\n", encoding="utf-8")
-    print(serialized)
+    print(f"Dry-run report written to {output_path}")
 
 
 def main(argv: list[str] | None = None) -> int:

--- a/tests/test_weather_backfill_dry_run.py
+++ b/tests/test_weather_backfill_dry_run.py
@@ -9,6 +9,7 @@ from scripts.weather_backfill_dry_run import (
     WeatherHour,
     build_dry_run_report,
     find_nearest_weather_hour,
+    validate_matched_report_row,
     validate_weather_row,
 )
 
@@ -18,7 +19,7 @@ def ts(value: str) -> datetime:
 
 
 def city() -> CityInput:
-    return CityInput(city_id="9", api_name="Monterrey", latitude=25.6866, longitude=-100.3161)
+    return CityInput(city_id=9, api_name="Monterrey", latitude=25.6866, longitude=-100.3161)
 
 
 def weather(timestamp: str, **overrides: float) -> WeatherHour:
@@ -71,7 +72,7 @@ def test_nearest_hour_tie_breaker_chooses_previous_hour() -> None:
 
 
 def test_weather_range_validation_flags_errors_and_warnings() -> None:
-    reading = AqiReadingInput(city_id="9", reading_timestamp=ts("2026-05-24T12:00:00Z"))
+    reading = AqiReadingInput(city_id=9, reading_timestamp=ts("2026-05-24T12:00:00Z"))
     issues = validate_weather_row(
         city=city(),
         reading=reading,
@@ -95,7 +96,7 @@ def test_weather_range_validation_flags_errors_and_warnings() -> None:
 
 def test_delta_temperature_and_humidity_vs_waqi_legacy_fields() -> None:
     reading = AqiReadingInput(
-        city_id="9",
+        city_id=9,
         reading_timestamp=ts("2026-05-24T12:00:00Z"),
         temperature_c=15.5,
         humidity_percent=20.0,
@@ -111,8 +112,23 @@ def test_delta_temperature_and_humidity_vs_waqi_legacy_fields() -> None:
     assert "large_humidity_delta_vs_waqi" in codes
 
 
+def test_matched_report_row_validates_weather_metadata_nullability() -> None:
+    reading = AqiReadingInput(city_id=9, reading_timestamp=ts("2026-05-24T12:00:00Z"))
+    issues = validate_matched_report_row(
+        city=city(),
+        reading=reading,
+        row={
+            "weather_temperature_c": 28.0,
+            "weather_timestamp": None,
+            "weather_provider": None,
+        },
+    )
+
+    assert {issue["code"] for issue in issues} == {"weather_nullability"}
+
+
 def test_report_uses_weather_wind_speed_kmh_not_legacy_ms() -> None:
-    reading = AqiReadingInput(city_id="9", reading_timestamp=ts("2026-05-24T12:00:00Z"))
+    reading = AqiReadingInput(city_id=9, reading_timestamp=ts("2026-05-24T12:00:00Z"))
     report = build_dry_run_report(
         cities=[city()],
         readings=[reading],
@@ -126,10 +142,25 @@ def test_report_uses_weather_wind_speed_kmh_not_legacy_ms() -> None:
     assert report["unit_contract"]["weather_wind_speed_field"] == "weather_wind_speed_kmh"
 
 
+def test_matched_report_row_flags_unit_violation() -> None:
+    reading = AqiReadingInput(city_id=9, reading_timestamp=ts("2026-05-24T12:00:00Z"))
+    issues = validate_matched_report_row(
+        city=city(),
+        reading=reading,
+        row={
+            "weather_provider": "open-meteo",
+            "weather_timestamp": "2026-05-24T12:00:00Z",
+            "weather_wind_speed_ms": 12.0,
+        },
+    )
+
+    assert {issue["code"] for issue in issues} == {"weather_wind_unit_violation"}
+
+
 def test_report_summary_and_city_results() -> None:
     readings = [
-        AqiReadingInput(city_id="9", reading_timestamp=ts("2026-05-24T12:00:00Z")),
-        AqiReadingInput(city_id="9", reading_timestamp=ts("2026-05-24T12:31:00Z")),
+        AqiReadingInput(city_id=9, reading_timestamp=ts("2026-05-24T12:00:00Z")),
+        AqiReadingInput(city_id=9, reading_timestamp=ts("2026-05-24T12:31:00Z")),
     ]
     report = build_dry_run_report(
         cities=[city()],
@@ -144,13 +175,16 @@ def test_report_summary_and_city_results() -> None:
     assert report["summary"]["target_aqi_rows"] == 2
     assert report["summary"]["matched_rows"] == 1
     assert report["summary"]["unmatched_rows"] == 1
-    assert report["city_results"][0]["city_id"] == "9"
+    assert report["city_results"][0]["city_id"] == 9
     assert report["city_results"][0]["matched_rows"] == 1
     assert report["city_results"][0]["unmatched_rows"] == 1
 
 
 def test_script_source_does_not_call_supabase_mutations() -> None:
-    source = Path("scripts/weather_backfill_dry_run.py").read_text(encoding="utf-8")
+    repo_root = Path(__file__).resolve().parents[1]
+    source = (repo_root / "scripts" / "weather_backfill_dry_run.py").read_text(
+        encoding="utf-8"
+    )
     forbidden_tokens = [
         ".insert(",
         ".update(",

--- a/tests/test_weather_backfill_dry_run.py
+++ b/tests/test_weather_backfill_dry_run.py
@@ -1,0 +1,165 @@
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from pathlib import Path
+
+from scripts.weather_backfill_dry_run import (
+    AqiReadingInput,
+    CityInput,
+    WeatherHour,
+    build_dry_run_report,
+    find_nearest_weather_hour,
+    validate_weather_row,
+)
+
+
+def ts(value: str) -> datetime:
+    return datetime.fromisoformat(value.replace("Z", "+00:00")).astimezone(timezone.utc)
+
+
+def city() -> CityInput:
+    return CityInput(city_id="9", api_name="Monterrey", latitude=25.6866, longitude=-100.3161)
+
+
+def weather(timestamp: str, **overrides: float) -> WeatherHour:
+    return WeatherHour(
+        timestamp=ts(timestamp),
+        temperature_c=overrides.get("temperature_c", 28.0),
+        humidity_percent=overrides.get("humidity_percent", 50.0),
+        wind_speed_kmh=overrides.get("wind_speed_kmh", 12.0),
+        wind_direction_deg=overrides.get("wind_direction_deg", 180.0),
+        wind_gust_kmh=overrides.get("wind_gust_kmh", 20.0),
+    )
+
+
+def test_nearest_hour_matching_within_threshold() -> None:
+    match, delta = find_nearest_weather_hour(
+        ts("2026-05-24T12:20:00Z"),
+        [
+            weather("2026-05-24T12:00:00Z"),
+            weather("2026-05-24T13:00:00Z"),
+        ],
+    )
+
+    assert match is not None
+    assert match.timestamp == ts("2026-05-24T12:00:00Z")
+    assert delta == 20
+
+
+def test_nearest_hour_threshold_over_30_minutes_rejects() -> None:
+    match, delta = find_nearest_weather_hour(
+        ts("2026-05-24T12:31:00Z"),
+        [weather("2026-05-24T12:00:00Z")],
+    )
+
+    assert match is None
+    assert delta == 31
+
+
+def test_nearest_hour_tie_breaker_chooses_previous_hour() -> None:
+    match, delta = find_nearest_weather_hour(
+        ts("2026-05-24T12:30:00Z"),
+        [
+            weather("2026-05-24T12:00:00Z"),
+            weather("2026-05-24T13:00:00Z"),
+        ],
+    )
+
+    assert match is not None
+    assert match.timestamp == ts("2026-05-24T12:00:00Z")
+    assert delta == 30
+
+
+def test_weather_range_validation_flags_errors_and_warnings() -> None:
+    reading = AqiReadingInput(city_id="9", reading_timestamp=ts("2026-05-24T12:00:00Z"))
+    issues = validate_weather_row(
+        city=city(),
+        reading=reading,
+        weather_hour=weather(
+            "2026-05-24T12:00:00Z",
+            temperature_c=75.0,
+            humidity_percent=101.0,
+            wind_speed_kmh=170.0,
+            wind_gust_kmh=230.0,
+            wind_direction_deg=361.0,
+        ),
+    )
+
+    codes = {issue["code"] for issue in issues}
+    assert "weather_temperature_out_of_hard_range" in codes
+    assert "weather_humidity_out_of_range" in codes
+    assert "weather_wind_speed_high_warning" in codes
+    assert "weather_wind_gust_high_warning" in codes
+    assert "weather_wind_direction_out_of_range" in codes
+
+
+def test_delta_temperature_and_humidity_vs_waqi_legacy_fields() -> None:
+    reading = AqiReadingInput(
+        city_id="9",
+        reading_timestamp=ts("2026-05-24T12:00:00Z"),
+        temperature_c=15.5,
+        humidity_percent=20.0,
+    )
+    issues = validate_weather_row(
+        city=city(),
+        reading=reading,
+        weather_hour=weather("2026-05-24T12:00:00Z", temperature_c=30.0, humidity_percent=55.0),
+    )
+
+    codes = {issue["code"] for issue in issues}
+    assert "large_temperature_delta_vs_waqi" in codes
+    assert "large_humidity_delta_vs_waqi" in codes
+
+
+def test_report_uses_weather_wind_speed_kmh_not_legacy_ms() -> None:
+    reading = AqiReadingInput(city_id="9", reading_timestamp=ts("2026-05-24T12:00:00Z"))
+    report = build_dry_run_report(
+        cities=[city()],
+        readings=[reading],
+        weather_fetcher=lambda _city, _start, _end: [weather("2026-05-24T12:00:00Z")],
+        generated_at=ts("2026-05-24T13:00:00Z"),
+    )
+
+    first_match = report["city_results"][0]["sample_matches"][0]
+    assert "weather_wind_speed_kmh" in first_match
+    assert "wind_speed_ms" not in first_match
+    assert report["unit_contract"]["weather_wind_speed_field"] == "weather_wind_speed_kmh"
+
+
+def test_report_summary_and_city_results() -> None:
+    readings = [
+        AqiReadingInput(city_id="9", reading_timestamp=ts("2026-05-24T12:00:00Z")),
+        AqiReadingInput(city_id="9", reading_timestamp=ts("2026-05-24T12:31:00Z")),
+    ]
+    report = build_dry_run_report(
+        cities=[city()],
+        readings=readings,
+        weather_fetcher=lambda _city, _start, _end: [weather("2026-05-24T12:00:00Z")],
+        generated_at=ts("2026-05-24T13:00:00Z"),
+    )
+
+    assert report["mode"] == "dry_run"
+    assert report["provider"] == "open-meteo"
+    assert report["summary"]["active_cities"] == 1
+    assert report["summary"]["target_aqi_rows"] == 2
+    assert report["summary"]["matched_rows"] == 1
+    assert report["summary"]["unmatched_rows"] == 1
+    assert report["city_results"][0]["city_id"] == "9"
+    assert report["city_results"][0]["matched_rows"] == 1
+    assert report["city_results"][0]["unmatched_rows"] == 1
+
+
+def test_script_source_does_not_call_supabase_mutations() -> None:
+    source = Path("scripts/weather_backfill_dry_run.py").read_text(encoding="utf-8")
+    forbidden_tokens = [
+        ".insert(",
+        ".update(",
+        ".delete(",
+        ".upsert(",
+        "apply_migration",
+        "SUPABASE_SERVICE_ROLE_KEY",
+        "get_supabase_client",
+    ]
+
+    for token in forbidden_tokens:
+        assert token not in source


### PR DESCRIPTION
## Summary
- Adds dry-run-only Open-Meteo weather context evidence tooling for Story 1.4.4.
- Keeps WAQI/AQICN as the AQI provider and leaves runtime ingestion, Supabase schema, RPCs, AQI history, city geolocation, workflow schedule, and frontend untouched.
- Generates a local JSON report from local city/AQI export files.

## What changed
- Added `scripts/weather_backfill_dry_run.py` for local JSON/CSV input, Open-Meteo Historical Weather lookup, nearest-hour matching, validation issues, per-city summaries, and stdout/file report output.
- Added `tests/test_weather_backfill_dry_run.py` with no-network unit coverage.
- Added `docs/weather-context-dry-run.md` with input format, run instructions, report interpretation, guarantees, and next steps.

## No-write guarantees
- No Supabase client dependency in the dry-run script.
- No production credential requirement.
- No database schema or migration change.
- No productive backfill.
- No frontend/runtime app change.
- No AQI provider or public data-contract change.
- Regression coverage checks the dry-run script source for forbidden database-mutation/client/secret markers.

## How to run dry-run
```bash
python scripts/weather_backfill_dry_run.py \
  --cities ./local/active-cities.json \
  --readings ./local/aqi-candidate-readings.json
```

Optional local evidence file:
```bash
python scripts/weather_backfill_dry_run.py \
  --cities ./local/active-cities.json \
  --readings ./local/aqi-candidate-readings.json \
  --window-days 60 \
  --output reports/weather-backfill-dry-run.json
```

## Validation coverage
- nearest-hour matching;
- threshold rejection above 30 minutes;
- previous-hour tie breaker;
- weather range validation;
- temperature and humidity deltas against WAQI legacy fields;
- wind-unit naming as `weather_wind_speed_kmh`;
- report `summary` and `city_results` shape;
- source-level no-write guard coverage.

## Area touched
- Pipeline: script, tests, docs only.
- App: read-only reference only; no changed files.
- BD MtyRespira: no changes.
- Core DB: no changes.
- Cloudflare: no changes.
- UX: documentation only; no public UI changes.

## Risks / pending items
- The script can call Open-Meteo when run manually by an operator; tests do not make real network calls.
- This PR does not include production dry-run evidence or Supabase exports.
- Storage contract decision remains pending for Story 1.4.5.
- No migration/RPC/frontend rollout should happen until dry-run evidence is reviewed.

## Rollback
- Revert this PR.
- Removes only the dry-run script, its tests, and the dry-run guide.
- No runtime, database, RPC, Cloudflare, frontend, or AQI-provider rollback required.