### PR TITLE
db: add weather context migration draft

### DIFF
--- a/docs/sql/add-weather-context-columns.sql.md
+++ b/docs/sql/add-weather-context-columns.sql.md
@@ -1,0 +1,209 @@
+# Draft SQL — Add canonical weather context columns
+
+Status: Story 1.4.6 draft only / not applied  
+Scope: `air_quality_readings` additive canonical weather context columns  
+Decision source: `docs/weather-contract-migration-proposal.md`, Option A  
+
+This file is intentionally stored under `docs/sql/` because this repository does not currently expose a clear `supabase/migrations`, `migrations`, or `sql` migration convention in version control.
+
+Do not treat this file as an applied production migration. A future approved DB story must decide how this draft is promoted into the repository's migration mechanism.
+
+## Contract notes
+
+- `reading_timestamp` remains the AQI provider measurement time.
+- `weather_timestamp` is the selected Open-Meteo hourly weather bucket.
+- `weather_wind_speed_kmh` is kilometers per hour.
+- Do not write km/h values into legacy fields named `*_ms`, including `wind_speed_ms`.
+- `temperature_c` remains legacy provider weather-like data and is not canonical weather context.
+- Weather provider failure or range validation failure must not invalidate AQI.
+- AQI, `main_pollutant_us`, historical AQI, geolocation, RPC contract, and frontend runtime stay unchanged by this draft.
+
+## Forward draft
+
+```sql
+-- Story 1.4.6 draft only. Not applied in this story.
+-- Purpose: add nullable canonical weather context columns without changing AQI fields.
+
+alter table public.air_quality_readings
+  add column if not exists weather_temperature_c real,
+  add column if not exists weather_humidity_percent smallint,
+  add column if not exists weather_wind_speed_kmh real,
+  add column if not exists weather_wind_direction_deg smallint,
+  add column if not exists weather_wind_gust_kmh real,
+  add column if not exists weather_provider text,
+  add column if not exists weather_timestamp timestamptz,
+  add column if not exists weather_source_payload jsonb,
+  add column if not exists weather_backfilled_at timestamptz;
+
+comment on column public.air_quality_readings.reading_timestamp is
+  'AQI provider measurement timestamp. Do not replace with weather bucket time.';
+
+comment on column public.air_quality_readings.weather_temperature_c is
+  'Canonical weather-context temperature in Celsius from the selected weather provider bucket. Legacy temperature_c is not canonical weather.';
+
+comment on column public.air_quality_readings.weather_humidity_percent is
+  'Canonical relative humidity percentage from the selected weather provider bucket. Valid range: 0..100.';
+
+comment on column public.air_quality_readings.weather_wind_speed_kmh is
+  'Canonical weather wind speed in kilometers per hour. Do not write km/h values into wind_speed_ms or any *_ms field.';
+
+comment on column public.air_quality_readings.weather_wind_direction_deg is
+  'Canonical weather wind direction in degrees from the selected weather provider bucket. Valid range: 0..360.';
+
+comment on column public.air_quality_readings.weather_wind_gust_kmh is
+  'Canonical weather wind gust in kilometers per hour from the selected weather provider bucket. Must be non-negative when present.';
+
+comment on column public.air_quality_readings.weather_provider is
+  'Canonical weather provider identifier, for example open-meteo. Required when canonical weather values are present.';
+
+comment on column public.air_quality_readings.weather_timestamp is
+  'Weather provider bucket timestamp. This is separate from reading_timestamp, which remains AQI measurement time.';
+
+comment on column public.air_quality_readings.weather_source_payload is
+  'Selected weather provider payload slice for traceability. Do not expose this payload directly in public frontend RPCs by default.';
+
+comment on column public.air_quality_readings.weather_backfilled_at is
+  'Timestamp set by a future approved weather backfill for rows enriched with canonical weather context.';
+
+-- Existing table safety: add checks as NOT VALID first, then validate later after
+-- production evidence confirms legacy rows and candidate backfill rows satisfy them.
+
+do $$
+begin
+  if not exists (
+    select 1 from pg_constraint
+    where conname = 'air_quality_readings_weather_temperature_c_range'
+  ) then
+    alter table public.air_quality_readings
+      add constraint air_quality_readings_weather_temperature_c_range
+      check (
+        weather_temperature_c is null
+        or weather_temperature_c between -50 and 60
+      ) not valid;
+  end if;
+
+  if not exists (
+    select 1 from pg_constraint
+    where conname = 'air_quality_readings_weather_humidity_percent_range'
+  ) then
+    alter table public.air_quality_readings
+      add constraint air_quality_readings_weather_humidity_percent_range
+      check (
+        weather_humidity_percent is null
+        or weather_humidity_percent between 0 and 100
+      ) not valid;
+  end if;
+
+  if not exists (
+    select 1 from pg_constraint
+    where conname = 'air_quality_readings_weather_wind_speed_kmh_nonnegative'
+  ) then
+    alter table public.air_quality_readings
+      add constraint air_quality_readings_weather_wind_speed_kmh_nonnegative
+      check (
+        weather_wind_speed_kmh is null
+        or weather_wind_speed_kmh >= 0
+      ) not valid;
+  end if;
+
+  if not exists (
+    select 1 from pg_constraint
+    where conname = 'air_quality_readings_weather_wind_direction_deg_range'
+  ) then
+    alter table public.air_quality_readings
+      add constraint air_quality_readings_weather_wind_direction_deg_range
+      check (
+        weather_wind_direction_deg is null
+        or weather_wind_direction_deg between 0 and 360
+      ) not valid;
+  end if;
+
+  if not exists (
+    select 1 from pg_constraint
+    where conname = 'air_quality_readings_weather_wind_gust_kmh_nonnegative'
+  ) then
+    alter table public.air_quality_readings
+      add constraint air_quality_readings_weather_wind_gust_kmh_nonnegative
+      check (
+        weather_wind_gust_kmh is null
+        or weather_wind_gust_kmh >= 0
+      ) not valid;
+  end if;
+
+  if not exists (
+    select 1 from pg_constraint
+    where conname = 'air_quality_readings_weather_metadata_required'
+  ) then
+    alter table public.air_quality_readings
+      add constraint air_quality_readings_weather_metadata_required
+      check (
+        (
+          weather_temperature_c is null
+          and weather_humidity_percent is null
+          and weather_wind_speed_kmh is null
+          and weather_wind_direction_deg is null
+          and weather_wind_gust_kmh is null
+          and weather_source_payload is null
+          and weather_backfilled_at is null
+        )
+        or (
+          weather_provider is not null
+          and weather_timestamp is not null
+        )
+      ) not valid;
+  end if;
+end $$;
+```
+
+## Future validation draft
+
+Run validation only in a future explicitly approved DB story after production evidence review:
+
+```sql
+-- Draft only. Validate each constraint separately in a controlled future DB story.
+
+alter table public.air_quality_readings
+  validate constraint air_quality_readings_weather_temperature_c_range;
+
+alter table public.air_quality_readings
+  validate constraint air_quality_readings_weather_humidity_percent_range;
+
+alter table public.air_quality_readings
+  validate constraint air_quality_readings_weather_wind_speed_kmh_nonnegative;
+
+alter table public.air_quality_readings
+  validate constraint air_quality_readings_weather_wind_direction_deg_range;
+
+alter table public.air_quality_readings
+  validate constraint air_quality_readings_weather_wind_gust_kmh_nonnegative;
+
+alter table public.air_quality_readings
+  validate constraint air_quality_readings_weather_metadata_required;
+```
+
+## Conceptual rollback draft
+
+Rollback must be coordinated with RPC/frontend consumers if these columns are ever exposed. Do not drop canonical weather columns after a consumer depends on them without first removing that dependency.
+
+```sql
+-- Story 1.4.6 rollback draft only. Not used in this story.
+
+alter table public.air_quality_readings
+  drop constraint if exists air_quality_readings_weather_metadata_required,
+  drop constraint if exists air_quality_readings_weather_wind_gust_kmh_nonnegative,
+  drop constraint if exists air_quality_readings_weather_wind_direction_deg_range,
+  drop constraint if exists air_quality_readings_weather_wind_speed_kmh_nonnegative,
+  drop constraint if exists air_quality_readings_weather_humidity_percent_range,
+  drop constraint if exists air_quality_readings_weather_temperature_c_range;
+
+alter table public.air_quality_readings
+  drop column if exists weather_backfilled_at,
+  drop column if exists weather_source_payload,
+  drop column if exists weather_timestamp,
+  drop column if exists weather_provider,
+  drop column if exists weather_wind_gust_kmh,
+  drop column if exists weather_wind_direction_deg,
+  drop column if exists weather_wind_speed_kmh,
+  drop column if exists weather_humidity_percent,
+  drop column if exists weather_temperature_c;
+```

--- a/docs/sql/add-weather-context-columns.sql.md
+++ b/docs/sql/add-weather-context-columns.sql.md
@@ -35,9 +35,6 @@ alter table public.air_quality_readings
   add column if not exists weather_source_payload jsonb,
   add column if not exists weather_backfilled_at timestamptz;
 
-comment on column public.air_quality_readings.reading_timestamp is
-  'AQI provider measurement timestamp. Do not replace with weather bucket time.';
-
 comment on column public.air_quality_readings.weather_temperature_c is
   'Canonical weather-context temperature in Celsius from the selected weather provider bucket. Legacy temperature_c is not canonical weather.';
 

--- a/docs/sql/add-weather-context-columns.sql.md
+++ b/docs/sql/add-weather-context-columns.sql.md
@@ -70,6 +70,7 @@ begin
   if not exists (
     select 1 from pg_constraint
     where conname = 'air_quality_readings_weather_temperature_c_range'
+      and conrelid = 'public.air_quality_readings'::regclass
   ) then
     alter table public.air_quality_readings
       add constraint air_quality_readings_weather_temperature_c_range
@@ -82,6 +83,7 @@ begin
   if not exists (
     select 1 from pg_constraint
     where conname = 'air_quality_readings_weather_humidity_percent_range'
+      and conrelid = 'public.air_quality_readings'::regclass
   ) then
     alter table public.air_quality_readings
       add constraint air_quality_readings_weather_humidity_percent_range
@@ -94,6 +96,7 @@ begin
   if not exists (
     select 1 from pg_constraint
     where conname = 'air_quality_readings_weather_wind_speed_kmh_nonnegative'
+      and conrelid = 'public.air_quality_readings'::regclass
   ) then
     alter table public.air_quality_readings
       add constraint air_quality_readings_weather_wind_speed_kmh_nonnegative
@@ -106,6 +109,7 @@ begin
   if not exists (
     select 1 from pg_constraint
     where conname = 'air_quality_readings_weather_wind_direction_deg_range'
+      and conrelid = 'public.air_quality_readings'::regclass
   ) then
     alter table public.air_quality_readings
       add constraint air_quality_readings_weather_wind_direction_deg_range
@@ -118,6 +122,7 @@ begin
   if not exists (
     select 1 from pg_constraint
     where conname = 'air_quality_readings_weather_wind_gust_kmh_nonnegative'
+      and conrelid = 'public.air_quality_readings'::regclass
   ) then
     alter table public.air_quality_readings
       add constraint air_quality_readings_weather_wind_gust_kmh_nonnegative
@@ -130,6 +135,7 @@ begin
   if not exists (
     select 1 from pg_constraint
     where conname = 'air_quality_readings_weather_metadata_required'
+      and conrelid = 'public.air_quality_readings'::regclass
   ) then
     alter table public.air_quality_readings
       add constraint air_quality_readings_weather_metadata_required

--- a/docs/weather-context-db-migration-draft.md
+++ b/docs/weather-context-db-migration-draft.md
@@ -120,24 +120,21 @@ git diff --name-only main...HEAD
 
 # Confirm no runtime files changed.
 git diff --name-only main...HEAD -- main.py update_city.py waqi_api.py utils.py .github/workflows
-
-# Confirm no live-write command wording was introduced.
-grep -RniE "apply_migration|supabase db push|psql" docs/weather-context-db-migration-draft.md docs/sql/add-weather-context-columns.sql.md || true
-
-# Confirm no secret assignments were introduced.
-grep -RniE "WAQI_API_TOKEN=|AIRVISUAL_API_KEY=|SUPABASE_SERVICE_ROLE_KEY=" docs/weather-context-db-migration-draft.md docs/sql/add-weather-context-columns.sql.md || true
-
-# Confirm no privileged DB guidance was added to frontend/app contexts.
-grep -RniE "frontend.*service_role|app.*service_role|VITE_.*SERVICE|public.*service_role" docs/weather-context-db-migration-draft.md docs/sql/add-weather-context-columns.sql.md || true
 ```
+
+Additional review checklist:
+
+- Search the changed docs for live DB apply command wording from the story prompt; there should be no executable live-apply instructions.
+- Search the changed docs for secret assignment patterns; there should be no real or placeholder secret assignment.
+- Search the changed docs for privileged database credential guidance in frontend/app contexts; there should be no such guidance.
 
 Expected result:
 
 - Only `docs/weather-context-db-migration-draft.md` and `docs/sql/add-weather-context-columns.sql.md` are changed.
 - Runtime diff is empty.
-- The live-write grep returns no matching instructions in the new docs.
-- The secret grep returns no secret assignments.
-- The frontend/app privileged credential grep returns no matches.
+- The live-write search returns no matching instructions in the new docs.
+- The secret search returns no secret assignments.
+- The frontend/app privileged credential search returns no matches.
 
 ## How to validate after a future approved DB apply
 

--- a/docs/weather-context-db-migration-draft.md
+++ b/docs/weather-context-db-migration-draft.md
@@ -25,8 +25,8 @@ Before creating this draft, the repo was checked for a clear migration conventio
 
 - `supabase/migrations`: not present.
 - `migrations`: not present.
-- `sql`: not present.
-- Existing weather contract docs only included conceptual SQL, not an applied migration convention.
+- No top-level `sql/` migration directory or versioned SQL migration convention was present.
+- Existing weather contract docs only included conceptual SQL and documentation examples, not an applied migration convention.
 
 Decision: do **not** invent a production migration structure in this story. Store the draft under `docs/sql/` until a future DB story defines the migration workflow.
 

--- a/docs/weather-context-db-migration-draft.md
+++ b/docs/weather-context-db-migration-draft.md
@@ -1,0 +1,186 @@
+# Weather Context DB Migration Draft — MtyRespira
+
+Status: Story 1.4.6 draft / not applied  
+Scope: `elelier/airquality_pipeline`  
+Reference app repo: `elelier/monterrey-respira` read-only  
+Decision type: Architecture / Data QA / DB migration draft / Docs
+
+## Purpose
+
+This document records the DB migration draft for adding canonical meteorological context to MtyRespira without changing production behavior in this story.
+
+The draft follows Story 1.4.5's recommendation: **Option A — additive canonical `weather_*` columns on `air_quality_readings`** for MtyRespira v1.
+
+The SQL draft lives at:
+
+```text
+docs/sql/add-weather-context-columns.sql.md
+```
+
+It is a documented SQL draft, not an applied migration.
+
+## Repository migration convention check
+
+Before creating this draft, the repo was checked for a clear migration convention:
+
+- `supabase/migrations`: not present.
+- `migrations`: not present.
+- `sql`: not present.
+- Existing weather contract docs only included conceptual SQL, not an applied migration convention.
+
+Decision: do **not** invent a production migration structure in this story. Store the draft under `docs/sql/` until a future DB story defines the migration workflow.
+
+## What the draft adds
+
+The draft adds nullable canonical weather-context columns to `public.air_quality_readings`:
+
+| Column | Purpose |
+| --- | --- |
+| `weather_temperature_c` | Canonical weather temperature in Celsius. |
+| `weather_humidity_percent` | Canonical relative humidity percentage. |
+| `weather_wind_speed_kmh` | Canonical wind speed in km/h. |
+| `weather_wind_direction_deg` | Canonical wind direction in degrees. |
+| `weather_wind_gust_kmh` | Canonical wind gust in km/h. |
+| `weather_provider` | Weather provider identifier, for example `open-meteo`. |
+| `weather_timestamp` | Weather provider bucket timestamp. |
+| `weather_source_payload` | Selected provider payload slice for traceability. |
+| `weather_backfilled_at` | Timestamp for a future approved weather backfill. |
+
+## Constraints included
+
+The draft includes safe check constraints as `NOT VALID` because the table already exists and production rows may need evidence review before validation.
+
+Included checks:
+
+- `weather_temperature_c` must be null or within `-50..60`.
+- `weather_humidity_percent` must be null or within `0..100`.
+- `weather_wind_speed_kmh` must be null or non-negative.
+- `weather_wind_direction_deg` must be null or within `0..360`.
+- `weather_wind_gust_kmh` must be null or non-negative.
+- If any canonical weather value, source payload, or backfill marker is present, `weather_provider` and `weather_timestamp` must also be present.
+
+## Contract rules preserved
+
+This story does not change the current production contract.
+
+The draft explicitly preserves these rules:
+
+- `reading_timestamp` remains AQI measurement time.
+- `weather_timestamp` is the selected weather bucket time.
+- `weather_wind_speed_kmh` is km/h.
+- Do not write km/h values into `wind_speed_ms` or any field named `*_ms`.
+- `temperature_c` remains legacy provider weather-like data and is not canonical weather context.
+- Weather provider failure must not invalidate AQI.
+- Weather validation failure must not invalidate AQI.
+- AQI, `main_pollutant_us`, historical AQI, geolocation, latest RPC behavior, and frontend runtime remain unchanged.
+
+## What this story does not change
+
+No changes were made to:
+
+- Supabase live DB.
+- DB migration history.
+- `main.py`.
+- `update_city.py`.
+- `waqi_api.py`.
+- `utils.py`.
+- workflow schedule.
+- AQI provider selection.
+- AQI values.
+- `main_pollutant_us`.
+- historical AQI.
+- city geolocation.
+- RPCs.
+- frontend code.
+- public UI copy.
+- Core DB.
+- Cloudflare.
+
+## Why this was not applied
+
+This story is intentionally no-write.
+
+The repo has no clear DB migration convention to safely place a production migration file. Creating `supabase/migrations` here would silently introduce a migration workflow without a project decision.
+
+A future DB implementation story should first confirm:
+
+1. where migrations live,
+2. how migration ordering is controlled,
+3. how DB drift is reviewed,
+4. how future constraint validation is scheduled,
+5. whether the SQL should remain Option A or be promoted to a versioned migration.
+
+## How to validate in branch/local
+
+Recommended branch review checks:
+
+```bash
+# Confirm touched files are docs/SQL-draft only.
+git diff --name-only main...HEAD
+
+# Confirm no runtime files changed.
+git diff --name-only main...HEAD -- main.py update_city.py waqi_api.py utils.py .github/workflows
+
+# Confirm no live-write command wording was introduced.
+grep -RniE "apply_migration|supabase db push|psql" docs/weather-context-db-migration-draft.md docs/sql/add-weather-context-columns.sql.md || true
+
+# Confirm no secret assignments were introduced.
+grep -RniE "WAQI_API_TOKEN=|AIRVISUAL_API_KEY=|SUPABASE_SERVICE_ROLE_KEY=" docs/weather-context-db-migration-draft.md docs/sql/add-weather-context-columns.sql.md || true
+
+# Confirm no privileged DB guidance was added to frontend/app contexts.
+grep -RniE "frontend.*service_role|app.*service_role|VITE_.*SERVICE|public.*service_role" docs/weather-context-db-migration-draft.md docs/sql/add-weather-context-columns.sql.md || true
+```
+
+Expected result:
+
+- Only `docs/weather-context-db-migration-draft.md` and `docs/sql/add-weather-context-columns.sql.md` are changed.
+- Runtime diff is empty.
+- The live-write grep returns no matching instructions in the new docs.
+- The secret grep returns no secret assignments.
+- The frontend/app privileged credential grep returns no matches.
+
+## How to validate after a future approved DB apply
+
+A later story that is explicitly approved to apply DB changes should produce evidence for:
+
+- Columns exist and are nullable.
+- Legacy AQI columns still exist.
+- `reading_timestamp` values remain unchanged.
+- `aqi_us` values remain unchanged.
+- `main_pollutant_us` values remain unchanged.
+- City coordinates remain unchanged.
+- Latest RPC remains compatible with current frontend expectations.
+- Constraint validation is reviewed separately from column creation.
+- Weather fields are null before any approved backfill unless a controlled canary update is part of that future story.
+- No canonical km/h value is written to `wind_speed_ms`.
+
+Future post-apply verification should be read-only evidence and should avoid exposing raw provider payloads in public frontend contracts by default.
+
+## Rollback concept
+
+For this story:
+
+1. Revert this PR.
+2. No DB rollback is needed.
+3. No runtime rollback is needed.
+4. No Cloudflare rollback is needed.
+5. No frontend rollback is needed.
+
+For a future story that actually applies the columns:
+
+1. First confirm no RPC/frontend consumer depends on the canonical `weather_*` columns.
+2. Drop the weather constraints.
+3. Drop only the newly added canonical `weather_*` columns.
+4. Do not drop or rewrite legacy `temperature_c`, `humidity_percent`, `wind_speed_ms`, `wind_direction_deg`, AQI fields, pollutant fields, timestamps, city identity, or geolocation.
+
+The SQL rollback draft is included in `docs/sql/add-weather-context-columns.sql.md` for planning only.
+
+## Risks / pending items
+
+- A production migration convention is still pending.
+- A future live DB story must not skip drift review.
+- Constraint validation should be separated from column creation if table size or existing data quality is uncertain.
+- Backfill remains pending and must start with dry-run evidence and explicit approval.
+- RPC extension remains pending and must be additive.
+- Frontend migration remains pending and must consume `weather_wind_speed_kmh` for km/h display.
+- The legacy `wind_speed_ms` unit-display risk remains until the app migrates away from legacy weather fields.


### PR DESCRIPTION
## Summary
- Adds Story 1.4.6 weather context DB migration draft documentation for MtyRespira.
- Keeps the change docs/SQL-draft only: no Supabase live apply, no migration execution, no backfill, no runtime/provider/frontend changes.
- Stores the SQL as `docs/sql/add-weather-context-columns.sql.md` because the repo does not currently expose a clear production migration convention.

## Decision / recommendation
- Follows Story 1.4.5 recommendation: **Option A — additive canonical `weather_*` columns on `air_quality_readings`** for MtyRespira v1.
- Does not introduce a new `supabase/migrations` convention in this story.
- Keeps Option B (`weather_context_readings`) as future v2 direction only, outside this PR.

## What changed
- Added `docs/sql/add-weather-context-columns.sql.md` with:
  - nullable canonical weather columns;
  - safe `NOT VALID` check constraints;
  - column comments documenting timestamp/unit/source boundaries;
  - future constraint-validation draft;
  - conceptual rollback draft.
- Added `docs/weather-context-db-migration-draft.md` with:
  - purpose;
  - migration convention check;
  - added columns and constraints;
  - what does and does not change;
  - branch/local validation guidance;
  - future post-apply validation guidance;
  - rollback concept;
  - risks and pending items.

## No-write guarantees
- No Supabase live DB changes.
- No migration executed.
- No production backfill.
- No runtime pipeline changes.
- No AQI provider changes.
- No RPC changes.
- No frontend changes.
- No workflow schedule changes.
- No AQI, `main_pollutant_us`, historical AQI, geolocation, or public contract mutation.
- No secrets added.
- No privileged DB credential guidance for frontend/app.

## Validation performed
- Reviewed required pipeline docs/code context including README, weather provider spike, dry-run guide/script/tests, and migration proposal.
- Reviewed app contract/reference context read-only, including shared data contract and AirQualityCard wind display risk.
- Checked repository migration convention paths by lookup/search: no clear `supabase/migrations`, `migrations`, or `sql` convention was found.
- Confirmed diff is docs/SQL-draft only:
  - `docs/sql/add-weather-context-columns.sql.md`
  - `docs/weather-context-db-migration-draft.md`
- Confirmed no runtime files were changed.
- Did not invoke Supabase write tools or live DB operations.
- Did not add runtime tests because this is docs/SQL-draft only and no existing docs/SQL validation framework was found.

## Area touched
- Pipeline: docs / SQL draft only.
- BD MtyRespira: draft planning only; no live DB change.
- App: read-only reference only; no changed files.
- Core DB: no changes.
- Cloudflare: no changes.
- UX: no public UI change; future risk documented.

## Risks / pending items
- Production migration convention remains pending.
- Future DB story must decide whether to promote this draft into a real versioned migration.
- Future DB story must review drift and apply/validate constraints deliberately.
- Backfill remains pending and requires dry-run evidence plus explicit approval.
- RPC extension remains pending and must be additive.
- Frontend migration remains pending; it should consume `weather_wind_speed_kmh` for km/h display.
- Legacy `wind_speed_ms` unit-display risk remains until the app migrates away from legacy weather fields.

## Rollback
- Revert this PR.
- Removes only:
  - `docs/sql/add-weather-context-columns.sql.md`
  - `docs/weather-context-db-migration-draft.md`
- No DB rollback required.
- No runtime rollback required.
- No RPC rollback required.
- No Cloudflare rollback required.
- No frontend rollback required.