### PR TITLE
docs: add DB migration convention readiness gate

### DIFF
--- a/docs/db-migration-convention.md
+++ b/docs/db-migration-convention.md
@@ -1,0 +1,177 @@
+# DB Migration Convention — MtyRespira Pipeline
+
+Status: proposed convention / not yet applied  
+Scope: `elelier/airquality_pipeline`  
+Decision type: Architecture / DB planning / Data QA / Docs
+
+## Purpose
+
+Define the minimum safe convention for future Supabase PostgreSQL migrations owned by the MtyRespira pipeline repository.
+
+This document does not create a production migration directory, move draft SQL, apply DDL, run backfills, or change runtime behavior.
+
+## Current repository finding
+
+As of Story 1.4.7, no accepted production migration convention was found in this repository.
+
+Checked locations and signals:
+
+- `supabase/migrations`: not present.
+- `migrations`: not present.
+- Top-level production `sql/`: not present.
+- Existing `docs/sql/` content is treated as documented SQL draft material, not a migration mechanism.
+- README and workflow documentation describe the pipeline and Supabase usage, but do not define versioned DB migration ownership or apply procedure.
+- No repository `AGENTS.md` was found in `elelier/airquality_pipeline` during this review.
+
+## Recommended future route
+
+When the project explicitly accepts a versioned DB migration convention, use:
+
+```text
+supabase/migrations/
+```
+
+Rationale:
+
+- It is recognizable as the Supabase migration directory.
+- It separates production migration files from documentation drafts.
+- It avoids treating `docs/sql/` as executable migration history.
+
+Do not create `supabase/migrations/` until a future implementation story is explicitly approved to promote a draft into a real migration.
+
+## Naming convention
+
+Use timestamp-prefixed snake_case names:
+
+```text
+YYYYMMDDHHMMSS_short_snake_case_description.sql
+```
+
+Example format only:
+
+```text
+20260524170000_add_weather_context_columns.sql
+```
+
+Rules:
+
+- Timestamp must represent when the migration file is authored, in UTC if the toolchain supports it.
+- Description must be lowercase snake_case.
+- One migration should do one coherent schema change.
+- Do not combine DDL, backfill, RPC changes, frontend changes, and provider runtime changes in the same migration story unless explicitly approved.
+
+## Review checklist for DB migration PRs
+
+Before opening a PR that adds a real migration file, confirm:
+
+- The migration directory convention has already been accepted.
+- The migration is on a dedicated branch.
+- SQL is additive when possible.
+- Existing AQI fields, `reading_timestamp`, `main_pollutant_us`, city identity, geolocation, and historical readings are not rewritten.
+- Constraints on existing tables are introduced with a safe strategy such as `NOT VALID` when appropriate.
+- Constraint validation is separated from initial DDL unless the story explicitly approves validation in the same PR.
+- Backfill is separated from DDL unless explicitly approved.
+- RPC or frontend contract changes are separated from DDL unless explicitly approved.
+- Rollback expectations are documented.
+- Drift checks are documented before and after apply.
+- No secrets are committed.
+- No privileged key guidance is added to frontend or public app code.
+
+## No live apply from docs-only PRs
+
+Documentation-only PRs must not apply migrations to Supabase.
+
+A docs-only PR may include:
+
+- Migration convention proposals.
+- SQL drafts under `docs/sql/`.
+- Readiness gates.
+- Review checklists.
+- Apply evidence templates.
+
+A docs-only PR must not include:
+
+- Live DDL execution.
+- Backfill execution.
+- Supabase write operations.
+- Runtime pipeline changes.
+- Frontend/app changes.
+- Workflow schedule changes.
+
+## When applying to Supabase is allowed
+
+A future Supabase apply is allowed only when all are true:
+
+1. A story explicitly authorizes DB apply.
+2. The target Supabase project is clearly identified.
+3. The migration file is versioned under the accepted migration directory.
+4. The SQL has been reviewed in PR.
+5. Drift evidence is captured before apply.
+6. Rollback expectations are documented.
+7. Apply evidence is captured after execution.
+8. No secrets are exposed in logs, docs, screenshots, artifacts, or PR comments.
+
+## Apply evidence expectations
+
+A future apply PR or follow-up evidence document should record:
+
+- Migration filename.
+- Commit SHA containing the migration.
+- Target environment and project identifier, without secrets.
+- Operator or automation used to apply.
+- Timestamp of apply.
+- Pre-apply drift check summary.
+- Post-apply schema verification summary.
+- Any warnings, locks, failures, retries, or manual interventions.
+- Confirmation that no AQI, pollutant, geolocation, historical reading, RPC, frontend, or provider behavior was changed unless explicitly in scope.
+
+Do not paste provider tokens, service keys, raw credentials, or full sensitive environment dumps into evidence.
+
+## Rollback expectations
+
+Every real migration PR must include rollback expectations.
+
+Minimum rollback notes:
+
+- Whether rollback is safe after consumers depend on the new schema.
+- Which constraints would be dropped first.
+- Which columns, indexes, or comments would be removed.
+- Which existing legacy columns must never be dropped by the rollback.
+- Whether rollback requires first removing RPC/frontend/runtime dependencies.
+
+For additive weather context migrations, rollback must not touch AQI fields, pollutant fields, `reading_timestamp`, city identity, city coordinates, or legacy provider fields unless a separate approved story explicitly scopes that work.
+
+## Drift checks
+
+Future DB migration stories should perform read-only drift checks before apply and after apply.
+
+Minimum pre-apply checks:
+
+- Confirm whether the target columns, constraints, indexes, RPCs, or comments already exist.
+- Confirm whether pending migrations exist outside repository history.
+- Confirm whether the target table shape matches the migration assumptions.
+
+Minimum post-apply checks:
+
+- Confirm expected columns or constraints exist.
+- Confirm unexpected runtime contract changes did not occur.
+- Confirm no public RPC output changed unless explicitly scoped.
+- Confirm no backfill happened unless explicitly approved.
+
+## Secrets and privileged access boundary
+
+Secrets must stay in local `.env` files or GitHub Actions Secrets.
+
+Do not commit secret assignment patterns or real values for:
+
+- `WAQI_API_TOKEN`
+- `AIRVISUAL_API_KEY`
+- `SUPABASE_SERVICE_ROLE_KEY`
+
+The Supabase service role key is a pipeline/server-side secret boundary only. It must never be added to frontend app code, public runtime configuration, documentation that instructs frontend usage, screenshots, or public artifacts.
+
+## Relationship to existing SQL drafts
+
+`docs/sql/` may continue to hold SQL drafts while a migration is still being designed.
+
+A file under `docs/sql/` is not migration history and must not be treated as applied. Promotion from draft to production migration requires a future story and the readiness gate defined for that migration.

--- a/docs/weather-context-migration-readiness-gate.md
+++ b/docs/weather-context-migration-readiness-gate.md
@@ -1,0 +1,191 @@
+# Weather Context Migration Readiness Gate — MtyRespira
+
+Status: readiness gate / not applied  
+Scope: promotion criteria for `docs/sql/add-weather-context-columns.sql.md`  
+Decision type: Architecture / DB planning / Data QA / Docs
+
+## Purpose
+
+Define the gate that must pass before the Story 1.4.6 SQL draft can be promoted into a real Supabase migration.
+
+This gate does not promote the draft, create a migration directory, apply DDL, run backfill, change runtime pipeline behavior, change RPCs, or change the frontend.
+
+## Source draft
+
+The current draft remains here:
+
+```text
+docs/sql/add-weather-context-columns.sql.md
+```
+
+It must stay a documentation draft until a future story explicitly promotes it under the accepted migration convention.
+
+## Promotion decision
+
+The draft may be promoted only when all gate checks below are satisfied.
+
+### 1. Convention accepted
+
+- `docs/db-migration-convention.md` has been reviewed and accepted, or superseded by a clearly documented project decision.
+- The accepted migration route is known before any production migration directory is created.
+- `docs/sql/` is still understood as draft-only, not applied migration history.
+
+### 2. Dedicated implementation branch
+
+- A new branch is created specifically for migration promotion.
+- The branch name makes the DDL scope clear.
+- No unrelated runtime, provider, frontend, workflow schedule, or backfill changes are included.
+
+### 3. SQL reviewed before promotion
+
+Review the draft SQL again before copying it into a real migration file.
+
+Required review points:
+
+- Columns are nullable and additive.
+- Existing AQI, pollutant, city identity, geolocation, and historical fields are not rewritten.
+- `reading_timestamp` remains AQI measurement time.
+- `weather_timestamp` remains weather provider bucket time.
+- `weather_wind_speed_kmh` remains km/h.
+- No km/h value is written to `wind_speed_ms` or any field named `*_ms`.
+- `temperature_c` remains legacy provider weather-like data and is not redefined as canonical weather.
+- `weather_source_payload` is traceability data and is not exposed to public frontend contracts by default.
+
+### 4. Fresh dry-run evidence updated
+
+Before promotion, update dry-run evidence for Open-Meteo/weather context using current provider behavior.
+
+Evidence must confirm:
+
+- Weather provider response is available for target city coordinates or stations.
+- Weather values are plausible for Monterrey-area context.
+- Weather provider failure remains non-blocking for AQI.
+- Weather validation failure remains non-blocking for AQI.
+- No AQI provider change is required.
+- No historical AQI rewrite is required.
+
+### 5. No backfill in the DDL story unless explicitly approved
+
+The migration promotion story should only add schema.
+
+Do not run a 60-day or any historical weather backfill in the same story unless the prompt explicitly approves it.
+
+If a backfill is approved in a later story, it must have its own dry-run evidence, row-count expectations, rollback/repair plan, and no AQI rewrite guarantee.
+
+### 6. No RPC or frontend changes in the DDL story
+
+Do not modify:
+
+- `get_latest_air_quality_per_city` or any other RPC.
+- Frontend context, cards, charts, labels, or unit display.
+- Public app contract.
+- Cloudflare configuration.
+
+RPC and frontend adoption must be separate additive stories after the columns exist and are verified.
+
+### 7. Rollback documented
+
+Before apply, document rollback expectations for the exact promoted migration.
+
+Minimum rollback expectations:
+
+- Drop weather constraints before dropping weather columns.
+- Do not drop legacy weather-like provider fields.
+- Do not touch AQI, `main_pollutant_us`, historical readings, city identity, geolocation, or `reading_timestamp`.
+- Confirm no RPC/frontend consumer depends on the new `weather_*` columns before rollback.
+
+### 8. `NOT VALID` constraint strategy confirmed
+
+The promoted migration should preserve `NOT VALID` for check constraints on the existing table unless a future story gives evidence that immediate validation is safe.
+
+Reason:
+
+- Existing rows may need review before constraint validation.
+- Validation can be scheduled separately to reduce risk and isolate failures.
+
+### 9. Post-apply validation separated
+
+Initial DDL apply and constraint validation should be separate unless explicitly approved.
+
+A later validation story should confirm:
+
+- Constraints are validatable against production data.
+- No weather backfill violates range checks.
+- No public contract changed unexpectedly.
+- AQI freshness and historical views still behave as expected.
+
+### 10. Drift and no-secret checks pass
+
+Before opening the promotion PR, include read-only checks for:
+
+- Existing columns and constraints on `public.air_quality_readings`.
+- Existing migration history in Supabase.
+- Unexpected manual schema drift.
+- Secret assignment patterns in changed files.
+- Privileged service-role guidance in frontend/app contexts.
+
+Do not expose secrets in the evidence.
+
+## Required no-write guarantees for the promotion PR
+
+The promotion PR must state whether it does or does not perform live apply.
+
+For the default migration-file PR, expected guarantees are:
+
+- No Supabase live apply in the PR.
+- No DDL executed from the PR.
+- No backfill executed.
+- No runtime pipeline changes.
+- No workflow schedule changes.
+- No frontend changes.
+- No AQI provider changes.
+- No changes to AQI, `main_pollutant_us`, historical AQI, geolocation, or public contract.
+- No service role key exposure.
+
+## Apply readiness checklist
+
+A future operator may apply only after these are true:
+
+- [ ] Migration convention accepted.
+- [ ] SQL promoted to a versioned migration file under the accepted route.
+- [ ] PR reviewed and merged, or an explicitly approved apply workflow references the exact commit.
+- [ ] Target Supabase project confirmed.
+- [ ] Pre-apply drift evidence captured.
+- [ ] Rollback expectations captured.
+- [ ] Apply authorization is explicit.
+- [ ] Post-apply verification plan ready.
+
+## Post-apply evidence checklist
+
+After a future approved apply, capture:
+
+- [ ] Migration filename and commit SHA.
+- [ ] Apply timestamp.
+- [ ] Target environment/project identifier without secrets.
+- [ ] Columns exist and are nullable.
+- [ ] Constraints exist as expected.
+- [ ] Constraints remain `NOT VALID` if validation is out of scope.
+- [ ] AQI columns still exist.
+- [ ] `reading_timestamp` values remain AQI measurement timestamps.
+- [ ] `main_pollutant_us` values remain untouched.
+- [ ] City geolocation remains untouched.
+- [ ] Latest RPC remains compatible with current frontend expectations.
+- [ ] Weather fields remain null unless a separate approved write path populated them.
+- [ ] No backfill occurred unless explicitly approved.
+
+## Exit criteria for this gate
+
+This readiness gate is satisfied when a reviewer can point to:
+
+1. Accepted migration convention.
+2. Fresh weather dry-run evidence.
+3. Reviewed SQL.
+4. Dedicated migration branch.
+5. Explicit no-backfill or approved-backfill scope.
+6. Explicit no-RPC/frontend scope.
+7. Rollback notes.
+8. Drift check evidence.
+9. No-secret/no-frontend-service-role evidence.
+10. A clear post-apply verification plan.
+
+Until then, `docs/sql/add-weather-context-columns.sql.md` must remain a draft.


### PR DESCRIPTION
## Summary

Adds docs-only DB migration planning guardrails for MtyRespira weather context work.

## Decision / recommendation

Recommend `supabase/migrations/` as the future accepted route for real Supabase PostgreSQL migrations, but this PR intentionally does not create that directory yet.

`docs/sql/` remains draft-only until a future approved DB story promotes a draft into a real migration.

## What changed

- Added `docs/db-migration-convention.md` with future migration route recommendation, timestamped snake_case naming, review checklist, no-live-apply rule for docs-only PRs, apply evidence expectations, rollback expectations, drift checks, and secrets/service-role boundaries.
- Added `docs/weather-context-migration-readiness-gate.md` with criteria for promoting `docs/sql/add-weather-context-columns.sql.md`, including accepted convention, dedicated branch, reviewed SQL, fresh dry-run evidence, no backfill by default, no RPC/frontend coupling, rollback notes, `NOT VALID` constraint strategy, separated validation, and drift/no-secret checks.

## No-write guarantees

- No Supabase live apply.
- No DDL executed.
- No backfill.
- No runtime app or pipeline changes.
- No provider AQI changes.
- No changes to AQI, `main_pollutant_us`, historical AQI, geolocation, RPC contract, or public frontend contract.
- No workflow schedule changes.
- No `supabase/migrations/` directory created.
- No SQL draft moved.
- No secrets committed.
- No service-role guidance added for frontend/app usage.

## Validation performed

- Compared `main...db/story-1-4-7-weather-migration-convention-readiness`.
- Confirmed docs-only diff:
  - `docs/db-migration-convention.md`
  - `docs/weather-context-migration-readiness-gate.md`
- Confirmed no production migration directory was added.
- Confirmed `docs/sql/add-weather-context-columns.sql.md` was not moved or modified.
- Searched for sensitive environment assignment patterns in changed content.
- Searched for frontend/app service-role wording regressions.
- Did not use Supabase write tools.
- Did not apply DDL.

## Area touched

Pipeline documentation only.

## Risks / pending items

- Migration convention still needs reviewer acceptance before any real migration is added.
- Future migration promotion must update dry-run evidence and perform drift checks.
- Future DB apply must be explicitly approved in a separate story.
- Constraint validation and backfill remain separate future work unless explicitly approved.

## Rollback

Revert this PR. No DB, runtime, Cloudflare, pipeline, workflow, or frontend rollback is needed because this PR is docs-only.