### PR TITLE
feat: add Open-Meteo weather context write path

### DIFF
--- a/main.py
+++ b/main.py
@@ -12,6 +12,7 @@ from sync_cities import sync_cities
 from update_city import update_city
 from utils import check_if_update_needed, compute_inter_city_delay, delay, setup_logging
 from waqi_api import fetch_air_quality_data as fetch_waqi_air_quality_data
+from weather_context import enrich_with_weather_context
 
 setup_logging()
 load_dotenv()
@@ -79,6 +80,8 @@ def build_summary(force_update: bool, provider: str) -> dict:
         "validation_failures": 0,
         "insert_errors": 0,
         "update_errors": 0,
+        "weather_context_success": 0,
+        "weather_context_errors": 0,
         "city_results": [],
         "sync_summary": None,
     }
@@ -109,6 +112,8 @@ def log_pipeline_summary(summary: dict) -> None:
     logging.info("Fallos de validacion: %s", safe_summary["validation_failures"])
     logging.info("Errores de insert: %s", safe_summary["insert_errors"])
     logging.info("Errores de update status: %s", safe_summary["update_errors"])
+    logging.info("Weather context exitoso: %s", safe_summary["weather_context_success"])
+    logging.info("Weather context errores: %s", safe_summary["weather_context_errors"])
 
     if safe_summary.get("sync_summary") is not None:
         logging.info("Sync summary: %s", safe_summary["sync_summary"])
@@ -189,6 +194,12 @@ def main(force_update=False) -> dict:
 
             fetch_result = fetch_provider_air_quality(provider, city, env)
             fetch_result["city_id"] = city["id"]
+            fetch_result = enrich_with_weather_context(fetch_result)
+            weather_context = fetch_result.get("weather_context") or {}
+            if weather_context.get("status") == "success":
+                summary["weather_context_success"] += 1
+            elif weather_context:
+                summary["weather_context_errors"] += 1
 
             update_result = update_city(fetch_or_skip_result=fetch_result)
             successful_insert = (
@@ -238,6 +249,8 @@ def main(force_update=False) -> dict:
                     "needed_update": True,
                     "fetch_status": fetch_result.get("status"),
                     "fetch_error_type": fetch_result.get("errorType"),
+                    "weather_context_status": weather_context.get("status"),
+                    "weather_context_error_type": weather_context.get("errorType"),
                     "reading_inserted": bool(update_result.get("readingInserted")),
                     "city_status_updated": bool(update_result.get("cityStatusUpdated")),
                     "insert_error": update_result.get("insertError"),

--- a/tests/test_update_city.py
+++ b/tests/test_update_city.py
@@ -40,6 +40,48 @@ def test_update_city_success(mock_supabase_client, success_fetch_result):
     mock_supabase_client.table.return_value.insert.assert_called_once()
     mock_supabase_client.table.return_value.update.return_value.eq.assert_called_once_with('id', 1)
 
+
+def test_update_city_maps_successful_weather_context(mock_supabase_client, success_fetch_result):
+    success_fetch_result['weather_context'] = {
+        'status': 'success',
+        'weather_temperature_c': 28,
+        'weather_humidity_percent': 50,
+        'weather_wind_speed_kmh': 12.5,
+        'weather_wind_direction_deg': 180,
+        'weather_wind_gust_kmh': 22.1,
+        'weather_provider': 'open-meteo',
+        'weather_timestamp': '2026-05-25T01:00:00+00:00',
+        'weather_source_payload': {'current': {'temperature_2m': 28}},
+    }
+
+    result = update_city(success_fetch_result)
+
+    assert result['readingInserted'] is True
+    inserted_payload = mock_supabase_client.table.return_value.insert.call_args.args[0]
+    assert inserted_payload['weather_temperature_c'] == 28
+    assert inserted_payload['weather_humidity_percent'] == 50
+    assert inserted_payload['weather_wind_speed_kmh'] == 12.5
+    assert inserted_payload['weather_wind_direction_deg'] == 180
+    assert inserted_payload['weather_wind_gust_kmh'] == 22.1
+    assert inserted_payload['weather_provider'] == 'open-meteo'
+    assert inserted_payload['weather_timestamp'] == '2026-05-25T01:00:00+00:00'
+    assert inserted_payload['weather_source_payload'] == {'current': {'temperature_2m': 28}}
+
+
+def test_update_city_ignores_failed_weather_context(mock_supabase_client, success_fetch_result):
+    success_fetch_result['weather_context'] = {
+        'status': 'error',
+        'provider': 'open-meteo',
+        'errorType': 'fetch_failed',
+    }
+
+    result = update_city(success_fetch_result)
+
+    assert result['readingInserted'] is True
+    inserted_payload = mock_supabase_client.table.return_value.insert.call_args.args[0]
+    assert 'weather_temperature_c' not in inserted_payload
+    assert 'weather_provider' not in inserted_payload
+
 def test_update_city_fetch_error(mock_supabase_client):
     """Test update_city when the fetch result indicates an error."""
     error_result = {

--- a/tests/test_weather_context.py
+++ b/tests/test_weather_context.py
@@ -1,0 +1,57 @@
+from weather_context import normalize_weather_payload, build_weather_error
+
+
+def test_normalize_weather_payload_success():
+    payload = {
+        "current": {
+            "time": "2026-05-25T01:00",
+            "temperature_2m": 28.5,
+            "relative_humidity_2m": 45,
+            "wind_speed_10m": 12.3,
+            "wind_direction_10m": 90,
+            "wind_gusts_10m": 20.1,
+        },
+        "current_units": {
+            "temperature_2m": "°C",
+            "wind_speed_10m": "km/h",
+        },
+    }
+
+    result = normalize_weather_payload(payload)
+
+    assert result["status"] == "success"
+    assert result["weather_provider"] == "open-meteo"
+    assert result["weather_timestamp"] == "2026-05-25T01:00:00+00:00"
+    assert result["weather_temperature_c"] == 28.5
+    assert result["weather_humidity_percent"] == 45
+    assert result["weather_wind_speed_kmh"] == 12.3
+    assert result["weather_wind_direction_deg"] == 90
+    assert result["weather_wind_gust_kmh"] == 20.1
+    assert result["weather_source_payload"]["current"]["temperature_2m"] == 28.5
+
+
+def test_normalize_weather_payload_rejects_invalid_range():
+    payload = {
+        "current": {
+            "time": "2026-05-25T01:00",
+            "temperature_2m": 99,
+            "relative_humidity_2m": 45,
+        }
+    }
+
+    result = normalize_weather_payload(payload)
+
+    assert result["status"] == "error"
+    assert result["errorType"] == "validation_failed"
+    assert "weather_temperature_c_out_of_range" in result["message"]
+
+
+def test_build_weather_error_shape():
+    result = build_weather_error("missing_coordinates", "lat/lon required")
+
+    assert result == {
+        "status": "error",
+        "provider": "open-meteo",
+        "errorType": "missing_coordinates",
+        "message": "lat/lon required",
+    }

--- a/tests/test_weather_context.py
+++ b/tests/test_weather_context.py
@@ -1,4 +1,6 @@
-from weather_context import normalize_weather_payload, build_weather_error
+from unittest.mock import MagicMock, patch
+
+from weather_context import build_weather_error, fetch_weather_context, normalize_weather_payload
 
 
 def test_normalize_weather_payload_success():
@@ -44,6 +46,20 @@ def test_normalize_weather_payload_rejects_invalid_range():
     assert result["status"] == "error"
     assert result["errorType"] == "validation_failed"
     assert "weather_temperature_c_out_of_range" in result["message"]
+
+
+def test_fetch_weather_context_handles_non_json_response():
+    response = MagicMock()
+    response.status_code = 200
+    response.raise_for_status.return_value = None
+    response.json.side_effect = ValueError("not json")
+
+    with patch("weather_context.requests.get", return_value=response):
+        result = fetch_weather_context(25.67, -100.31)
+
+    assert result["status"] == "error"
+    assert result["provider"] == "open-meteo"
+    assert result["errorType"] == "invalid_json"
 
 
 def test_build_weather_error_shape():

--- a/tests/test_weather_context.py
+++ b/tests/test_weather_context.py
@@ -1,6 +1,12 @@
 from unittest.mock import MagicMock, patch
 
-from weather_context import build_weather_error, fetch_weather_context, normalize_weather_payload
+from weather_context import (
+    build_weather_error,
+    fetch_weather_context,
+    normalize_weather_payload,
+    parse_int,
+    parse_number,
+)
 
 
 def test_normalize_weather_payload_success():
@@ -46,6 +52,37 @@ def test_normalize_weather_payload_rejects_invalid_range():
     assert result["status"] == "error"
     assert result["errorType"] == "validation_failed"
     assert "weather_temperature_c_out_of_range" in result["message"]
+
+
+def test_normalize_weather_payload_drops_non_finite_values_before_success():
+    payload = {
+        "current": {
+            "time": "2026-05-25T01:00",
+            "temperature_2m": float("nan"),
+            "relative_humidity_2m": float("inf"),
+            "wind_speed_10m": float("nan"),
+            "wind_direction_10m": float("inf"),
+            "wind_gusts_10m": float("inf"),
+        }
+    }
+
+    result = normalize_weather_payload(payload)
+
+    assert result["status"] == "success"
+    assert result["weather_temperature_c"] is None
+    assert result["weather_humidity_percent"] is None
+    assert result["weather_wind_speed_kmh"] is None
+    assert result["weather_wind_direction_deg"] is None
+    assert result["weather_wind_gust_kmh"] is None
+
+
+def test_parse_helpers_return_none_for_non_finite_values():
+    assert parse_number(float("nan")) is None
+    assert parse_number(float("inf")) is None
+    assert parse_number("nan") is None
+    assert parse_number("inf") is None
+    assert parse_int(float("nan")) is None
+    assert parse_int(float("inf")) is None
 
 
 def test_fetch_weather_context_handles_non_json_response():

--- a/update_city.py
+++ b/update_city.py
@@ -3,6 +3,7 @@ import logging
 from supabase_client import get_supabase_client, log_pipeline_event
 from utils import validate_reading_payload
 
+
 def update_city(fetch_or_skip_result: dict) -> dict:
     logging.info("--- Iniciando update_city.py ---")
 
@@ -38,6 +39,8 @@ def update_city(fetch_or_skip_result: dict) -> dict:
                     }
                     logging.warning(f"Lectura rechazada por validacion: {validation_errors}")
                 else:
+                    weather_context = data.get('weather_context') or {}
+                    has_valid_weather_context = weather_context.get('status') == 'success'
                     reading_data_to_insert = {
                         'city_id': data['city_id'],
                         'reading_timestamp': reading_ts,
@@ -51,6 +54,18 @@ def update_city(fetch_or_skip_result: dict) -> dict:
                         'weather_icon': data.get('clima', {}).get('icono_clima'),
                         'raw_api_response': data.get('api_raw_response')
                     }
+
+                    if has_valid_weather_context:
+                        reading_data_to_insert.update({
+                            'weather_temperature_c': weather_context.get('weather_temperature_c'),
+                            'weather_humidity_percent': weather_context.get('weather_humidity_percent'),
+                            'weather_wind_speed_kmh': weather_context.get('weather_wind_speed_kmh'),
+                            'weather_wind_direction_deg': weather_context.get('weather_wind_direction_deg'),
+                            'weather_wind_gust_kmh': weather_context.get('weather_wind_gust_kmh'),
+                            'weather_provider': weather_context.get('weather_provider'),
+                            'weather_timestamp': weather_context.get('weather_timestamp'),
+                            'weather_source_payload': weather_context.get('weather_source_payload'),
+                        })
 
                     city_status_to_update = {
                         'last_successful_update_at': datetime.utcnow().isoformat(),
@@ -131,4 +146,3 @@ def update_city(fetch_or_skip_result: dict) -> dict:
     logging.info("--- Fin update_city.py ---")
     logging.info(result)
     return result
-

--- a/weather_context.py
+++ b/weather_context.py
@@ -1,7 +1,126 @@
+import logging
 from datetime import datetime, timezone
 from typing import Any
 
+import requests
+
 PROVIDER_NAME = "open-meteo"
+FORECAST_URL = "https://api.open-meteo.com/v1/forecast"
+TIMEOUT_SECONDS = 20
+CURRENT_FIELDS = (
+    "temperature_2m",
+    "relative_humidity_2m",
+    "wind_speed_10m",
+    "wind_direction_10m",
+    "wind_gusts_10m",
+)
+
+
+def enrich_with_weather_context(reading: dict[str, Any]) -> dict[str, Any]:
+    if reading.get("status") != "success":
+        return reading
+
+    coordinates = reading.get("coordenadas") if isinstance(reading.get("coordenadas"), dict) else {}
+    context = fetch_weather_context(coordinates.get("lat"), coordinates.get("lon"))
+    return {**reading, "weather_context": context}
+
+
+def fetch_weather_context(lat: Any, lon: Any) -> dict[str, Any]:
+    parsed_lat = parse_number(lat)
+    parsed_lon = parse_number(lon)
+    if parsed_lat is None or parsed_lon is None:
+        return build_weather_error("missing_coordinates", "Weather context requires lat/lon.")
+
+    try:
+        response = requests.get(
+            FORECAST_URL,
+            params={
+                "latitude": parsed_lat,
+                "longitude": parsed_lon,
+                "current": ",".join(CURRENT_FIELDS),
+                "temperature_unit": "celsius",
+                "wind_speed_unit": "kmh",
+                "timeformat": "iso8601",
+                "timezone": "UTC",
+            },
+            timeout=TIMEOUT_SECONDS,
+        )
+        logging.info("[Weather] HTTP GET status=%s", response.status_code)
+        response.raise_for_status()
+    except Exception as error:
+        return build_weather_error("fetch_failed", str(error))
+
+    payload = response.json()
+    if not isinstance(payload, dict):
+        return build_weather_error("invalid_payload", "Weather payload is not an object.")
+
+    return normalize_weather_payload(payload)
+
+
+def normalize_weather_payload(payload: dict[str, Any]) -> dict[str, Any]:
+    current = payload.get("current")
+    if not isinstance(current, dict):
+        return build_weather_error("missing_current", "Weather payload has no current object.")
+
+    timestamp = normalize_timestamp(current.get("time"))
+    if not timestamp:
+        return build_weather_error("missing_timestamp", "Weather payload has no valid time.")
+
+    context = {
+        "status": "success",
+        "weather_temperature_c": parse_number(current.get("temperature_2m")),
+        "weather_humidity_percent": parse_int(current.get("relative_humidity_2m")),
+        "weather_wind_speed_kmh": parse_number(current.get("wind_speed_10m")),
+        "weather_wind_direction_deg": parse_int(current.get("wind_direction_10m")),
+        "weather_wind_gust_kmh": parse_number(current.get("wind_gusts_10m")),
+        "weather_provider": PROVIDER_NAME,
+        "weather_timestamp": timestamp,
+        "weather_source_payload": {
+            "current": {
+                key: current.get(key)
+                for key in ("time", *CURRENT_FIELDS)
+                if key in current
+            },
+            "current_units": payload.get("current_units"),
+        },
+    }
+
+    errors = validate_weather_context(context)
+    if errors:
+        return build_weather_error("validation_failed", ",".join(errors))
+
+    return context
+
+
+def validate_weather_context(context: dict[str, Any]) -> list[str]:
+    errors = []
+    temperature = context.get("weather_temperature_c")
+    humidity = context.get("weather_humidity_percent")
+    wind_speed = context.get("weather_wind_speed_kmh")
+    wind_direction = context.get("weather_wind_direction_deg")
+    wind_gust = context.get("weather_wind_gust_kmh")
+
+    if temperature is not None and not (-50 <= temperature <= 60):
+        errors.append("weather_temperature_c_out_of_range")
+    if humidity is not None and not (0 <= humidity <= 100):
+        errors.append("weather_humidity_percent_out_of_range")
+    if wind_speed is not None and wind_speed < 0:
+        errors.append("weather_wind_speed_kmh_negative")
+    if wind_direction is not None and not (0 <= wind_direction <= 360):
+        errors.append("weather_wind_direction_deg_out_of_range")
+    if wind_gust is not None and wind_gust < 0:
+        errors.append("weather_wind_gust_kmh_negative")
+
+    has_weather_value = any(
+        value is not None
+        for value in (temperature, humidity, wind_speed, wind_direction, wind_gust)
+    )
+    if has_weather_value and not context.get("weather_provider"):
+        errors.append("missing_weather_provider")
+    if has_weather_value and not context.get("weather_timestamp"):
+        errors.append("missing_weather_timestamp")
+
+    return errors
 
 
 def parse_number(value: Any) -> int | float | None:
@@ -43,6 +162,7 @@ def normalize_timestamp(value: Any) -> str | None:
 
 
 def build_weather_error(error_type: str, message: str) -> dict[str, Any]:
+    logging.warning("[Weather] %s: %s", error_type, message)
     return {
         "status": "error",
         "provider": PROVIDER_NAME,

--- a/weather_context.py
+++ b/weather_context.py
@@ -47,10 +47,12 @@ def fetch_weather_context(lat: Any, lon: Any) -> dict[str, Any]:
         )
         logging.info("[Weather] HTTP GET status=%s", response.status_code)
         response.raise_for_status()
+        payload = response.json()
+    except ValueError as error:
+        return build_weather_error("invalid_json", str(error))
     except Exception as error:
         return build_weather_error("fetch_failed", str(error))
 
-    payload = response.json()
     if not isinstance(payload, dict):
         return build_weather_error("invalid_payload", "Weather payload is not an object.")
 

--- a/weather_context.py
+++ b/weather_context.py
@@ -1,0 +1,51 @@
+from datetime import datetime, timezone
+from typing import Any
+
+PROVIDER_NAME = "open-meteo"
+
+
+def parse_number(value: Any) -> int | float | None:
+    if isinstance(value, bool) or value is None:
+        return None
+    if isinstance(value, (int, float)):
+        return value
+    if isinstance(value, str):
+        try:
+            parsed = float(value)
+        except ValueError:
+            return None
+        return int(parsed) if parsed.is_integer() else parsed
+    return None
+
+
+def parse_int(value: Any) -> int | None:
+    parsed = parse_number(value)
+    if parsed is None:
+        return None
+    return int(round(parsed))
+
+
+def normalize_timestamp(value: Any) -> str | None:
+    if not value:
+        return None
+    clean_value = str(value).strip()
+    if not clean_value:
+        return None
+    if clean_value.endswith("Z"):
+        clean_value = f"{clean_value[:-1]}+00:00"
+    try:
+        parsed = datetime.fromisoformat(clean_value)
+    except ValueError:
+        return None
+    if parsed.tzinfo is None:
+        parsed = parsed.replace(tzinfo=timezone.utc)
+    return parsed.astimezone(timezone.utc).isoformat()
+
+
+def build_weather_error(error_type: str, message: str) -> dict[str, Any]:
+    return {
+        "status": "error",
+        "provider": PROVIDER_NAME,
+        "errorType": error_type,
+        "message": message,
+    }

--- a/weather_context.py
+++ b/weather_context.py
@@ -1,4 +1,5 @@
 import logging
+import math
 from datetime import datetime, timezone
 from typing import Any
 
@@ -102,16 +103,31 @@ def validate_weather_context(context: dict[str, Any]) -> list[str]:
     wind_direction = context.get("weather_wind_direction_deg")
     wind_gust = context.get("weather_wind_gust_kmh")
 
-    if temperature is not None and not (-50 <= temperature <= 60):
-        errors.append("weather_temperature_c_out_of_range")
-    if humidity is not None and not (0 <= humidity <= 100):
-        errors.append("weather_humidity_percent_out_of_range")
-    if wind_speed is not None and wind_speed < 0:
-        errors.append("weather_wind_speed_kmh_negative")
-    if wind_direction is not None and not (0 <= wind_direction <= 360):
-        errors.append("weather_wind_direction_deg_out_of_range")
-    if wind_gust is not None and wind_gust < 0:
-        errors.append("weather_wind_gust_kmh_negative")
+    if temperature is not None:
+        if not is_finite_number(temperature):
+            errors.append("weather_temperature_c_not_finite")
+        elif not (-50 <= temperature <= 60):
+            errors.append("weather_temperature_c_out_of_range")
+    if humidity is not None:
+        if not is_finite_number(humidity):
+            errors.append("weather_humidity_percent_not_finite")
+        elif not (0 <= humidity <= 100):
+            errors.append("weather_humidity_percent_out_of_range")
+    if wind_speed is not None:
+        if not is_finite_number(wind_speed):
+            errors.append("weather_wind_speed_kmh_not_finite")
+        elif wind_speed < 0:
+            errors.append("weather_wind_speed_kmh_negative")
+    if wind_direction is not None:
+        if not is_finite_number(wind_direction):
+            errors.append("weather_wind_direction_deg_not_finite")
+        elif not (0 <= wind_direction <= 360):
+            errors.append("weather_wind_direction_deg_out_of_range")
+    if wind_gust is not None:
+        if not is_finite_number(wind_gust):
+            errors.append("weather_wind_gust_kmh_not_finite")
+        elif wind_gust < 0:
+            errors.append("weather_wind_gust_kmh_negative")
 
     has_weather_value = any(
         value is not None
@@ -125,15 +141,23 @@ def validate_weather_context(context: dict[str, Any]) -> list[str]:
     return errors
 
 
+def is_finite_number(value: Any) -> bool:
+    return isinstance(value, (int, float)) and not isinstance(value, bool) and math.isfinite(value)
+
+
 def parse_number(value: Any) -> int | float | None:
     if isinstance(value, bool) or value is None:
         return None
     if isinstance(value, (int, float)):
+        if not math.isfinite(value):
+            return None
         return value
     if isinstance(value, str):
         try:
             parsed = float(value)
         except ValueError:
+            return None
+        if not math.isfinite(parsed):
             return None
         return int(parsed) if parsed.is_integer() else parsed
     return None


### PR DESCRIPTION
## Summary

Adds a non-blocking Open-Meteo weather context write path for future AQI readings.

## What changed

- Added `weather_context.py` for Open-Meteo current weather context normalization and validation.
- Enriched successful AQI fetch results before insert.
- Persisted canonical `weather_*` columns only when weather context succeeds.
- Added summary counters for weather context success/error.
- Added tests for weather normalization and `update_city` weather mapping.

## Boundaries

- No backfill.
- No RPC changes.
- No frontend changes.
- No workflow schedule changes.
- No AQI provider changes.
- Weather failure remains non-blocking for AQI inserts.

## Validation performed

- Compared `main...w`.
- Confirmed changed files are limited to pipeline write-path code and tests.
- Did not execute live pipeline.
- Did not run backfill.
- Did not apply DDL.

## Area touched

Pipeline only.

## Risks / pending items

- CI should run tests in GitHub Actions.
- First production run should be observed to confirm weather context success/error counters.
- Backfill, RPC exposure, frontend consumption, and constraint validation remain separate future stories.

## Rollback

Revert this PR. The DB schema can remain as-is; no rollback is required unless a future consumer depends on weather writes.