### PR TITLE
db: expose weather context in latest RPC

### DIFF
--- a/docs/weather-context-latest-rpc-contract.md
+++ b/docs/weather-context-latest-rpc-contract.md
@@ -34,6 +34,19 @@ The migration preserves all existing returned columns and appends these nullable
 
 The RPC intentionally does not expose `weather_source_payload`.
 
+## Migration strategy
+
+PostgreSQL does not allow changing an existing function return signature with `create or replace function` alone.
+
+Because this migration appends returned columns to `get_latest_air_quality_per_city()`, it intentionally uses:
+
+```sql
+drop function if exists public.get_latest_air_quality_per_city();
+create function public.get_latest_air_quality_per_city() ...
+```
+
+This is required so the updated `RETURNS TABLE` signature can be recreated cleanly.
+
 ## Compatibility
 
 Existing columns remain in the same order before the appended weather fields:

--- a/docs/weather-context-latest-rpc-contract.md
+++ b/docs/weather-context-latest-rpc-contract.md
@@ -1,0 +1,73 @@
+# Weather Context Latest RPC Contract — MtyRespira
+
+Status: migration drafted / not applied  
+Scope: `get_latest_air_quality_per_city`  
+Decision type: DB contract / Data QA / Docs
+
+## Purpose
+
+Expose canonical weather context fields through the existing public latest-air-quality RPC so the frontend can stop reading unreliable legacy weather-like fields for current weather display.
+
+Migration file:
+
+```text
+supabase/migrations/20260525045500_update_latest_air_quality_rpc_weather_context.sql
+```
+
+## Current problem
+
+Production still shows unrealistic temperature because the app receives and maps legacy fields such as `temperature_c` from the existing latest RPC.
+
+The canonical weather context columns already exist in `public.air_quality_readings`, but the latest RPC does not expose them yet.
+
+## Contract change
+
+The migration preserves all existing returned columns and appends these nullable fields:
+
+- `weather_temperature_c`
+- `weather_humidity_percent`
+- `weather_wind_speed_kmh`
+- `weather_wind_direction_deg`
+- `weather_wind_gust_kmh`
+- `weather_provider`
+- `weather_timestamp`
+
+The RPC intentionally does not expose `weather_source_payload`.
+
+## Compatibility
+
+Existing columns remain in the same order before the appended weather fields:
+
+- AQI fields remain unchanged.
+- `reading_timestamp` remains AQI measurement time.
+- Legacy weather-like fields remain available for backward compatibility.
+- New canonical weather fields are nullable because not every row has Open-Meteo context yet.
+
+## No-write guarantees for this PR
+
+This PR does not perform:
+
+- Supabase live apply,
+- backfill,
+- data updates,
+- frontend changes,
+- runtime pipeline changes,
+- workflow schedule changes,
+- AQI provider changes.
+
+## Required follow-up
+
+After this migration is reviewed and applied, the frontend should update its `CityAirQualityData` type and prefer canonical weather fields for display:
+
+- `weather_temperature_c`
+- `weather_humidity_percent`
+- `weather_wind_speed_kmh`
+- `weather_wind_direction_deg`
+
+If canonical weather is missing, the frontend should display weather as unavailable instead of falling back to unreliable legacy fields.
+
+## Rollback
+
+Rollback by restoring the previous `get_latest_air_quality_per_city` function definition captured before this migration.
+
+Rollback should not touch AQI readings, historical rows, city geolocation, or canonical weather columns.

--- a/supabase/migrations/20260525045500_update_latest_air_quality_rpc_weather_context.sql
+++ b/supabase/migrations/20260525045500_update_latest_air_quality_rpc_weather_context.sql
@@ -1,0 +1,85 @@
+create or replace function public.get_latest_air_quality_per_city()
+returns table(
+  city_id bigint,
+  city_name text,
+  api_name text,
+  latitude double precision,
+  longitude double precision,
+  reading_timestamp timestamp with time zone,
+  aqi_us smallint,
+  main_pollutant_us text,
+  temperature_c real,
+  humidity_percent smallint,
+  wind_speed_ms real,
+  wind_direction_deg smallint,
+  weather_icon text,
+  last_successful_update_at timestamp with time zone,
+  weather_temperature_c real,
+  weather_humidity_percent smallint,
+  weather_wind_speed_kmh real,
+  weather_wind_direction_deg smallint,
+  weather_wind_gust_kmh real,
+  weather_provider text,
+  weather_timestamp timestamp with time zone
+)
+language sql
+stable
+security definer
+as $function$
+  with ranked_readings as (
+    select
+      aqr.city_id,
+      c.name as city_name,
+      c.api_name as api_name,
+      c.latitude,
+      c.longitude,
+      c.last_successful_update_at,
+      aqr.reading_timestamp,
+      aqr.aqi_us,
+      aqr.main_pollutant_us,
+      aqr.temperature_c,
+      aqr.humidity_percent,
+      aqr.wind_speed_ms,
+      aqr.wind_direction_deg,
+      aqr.weather_icon,
+      aqr.weather_temperature_c,
+      aqr.weather_humidity_percent,
+      aqr.weather_wind_speed_kmh,
+      aqr.weather_wind_direction_deg,
+      aqr.weather_wind_gust_kmh,
+      aqr.weather_provider,
+      aqr.weather_timestamp,
+      row_number() over (
+        partition by aqr.city_id
+        order by aqr.reading_timestamp desc
+      ) as rn
+    from public.air_quality_readings aqr
+    join public.cities c on aqr.city_id = c.id
+    where c.is_active = true
+  )
+  select
+    rr.city_id,
+    rr.city_name,
+    rr.api_name,
+    rr.latitude,
+    rr.longitude,
+    rr.reading_timestamp,
+    rr.aqi_us,
+    rr.main_pollutant_us,
+    rr.temperature_c,
+    rr.humidity_percent,
+    rr.wind_speed_ms,
+    rr.wind_direction_deg,
+    rr.weather_icon,
+    rr.last_successful_update_at,
+    rr.weather_temperature_c,
+    rr.weather_humidity_percent,
+    rr.weather_wind_speed_kmh,
+    rr.weather_wind_direction_deg,
+    rr.weather_wind_gust_kmh,
+    rr.weather_provider,
+    rr.weather_timestamp
+  from ranked_readings rr
+  where rr.rn = 1
+  order by rr.city_name asc;
+$function$;

--- a/supabase/migrations/20260525045500_update_latest_air_quality_rpc_weather_context.sql
+++ b/supabase/migrations/20260525045500_update_latest_air_quality_rpc_weather_context.sql
@@ -1,4 +1,6 @@
-create or replace function public.get_latest_air_quality_per_city()
+drop function if exists public.get_latest_air_quality_per_city();
+
+create function public.get_latest_air_quality_per_city()
 returns table(
   city_id bigint,
   city_name text,


### PR DESCRIPTION
## Summary

Adds a versioned migration to update `get_latest_air_quality_per_city` so the public latest-air-quality contract can expose canonical weather context fields.

## What changed

- Added `supabase/migrations/20260525045500_update_latest_air_quality_rpc_weather_context.sql`.
- Added `docs/weather-context-latest-rpc-contract.md`.
- Preserves all existing RPC output columns.
- Appends nullable `weather_*` fields for frontend adoption.
- Does not expose `weather_source_payload`.

## No-write guarantees

- No Supabase live apply in this PR.
- No backfill.
- No data updates.
- No frontend changes.
- No runtime pipeline changes.
- No workflow schedule changes.
- No AQI provider changes.

## Validation performed

- Read current live function definition via Supabase read-only query.
- Compared `main...rpc-weather`.
- Confirmed diff is limited to one migration file and one documentation note.

## Area touched

Pipeline DB migration documentation only.

## Risks / pending items

- Migration still needs review and live apply before the frontend can consume the new fields.
- After apply, frontend must stop displaying legacy `temperature_c` as current weather and prefer canonical `weather_temperature_c`.
- Rows without Open-Meteo context will still have null canonical weather until future inserts/backfill.

## Rollback

Restore the previous `get_latest_air_quality_per_city` function definition captured before this migration. No table rollback is needed.