### PR TITLE
fix: use canonical city coordinates for weather context

### DIFF
--- a/main.py
+++ b/main.py
@@ -194,7 +194,11 @@ def main(force_update=False) -> dict:
 
             fetch_result = fetch_provider_air_quality(provider, city, env)
             fetch_result["city_id"] = city["id"]
-            fetch_result = enrich_with_weather_context(fetch_result)
+            fetch_result = enrich_with_weather_context(
+                fetch_result,
+                canonical_lat=city.get("latitude"),
+                canonical_lon=city.get("longitude"),
+            )
             weather_context = fetch_result.get("weather_context") or {}
             if weather_context.get("status") == "success":
                 summary["weather_context_success"] += 1

--- a/tests/test_weather_context.py
+++ b/tests/test_weather_context.py
@@ -2,11 +2,40 @@ from unittest.mock import MagicMock, patch
 
 from weather_context import (
     build_weather_error,
+    enrich_with_weather_context,
     fetch_weather_context,
     normalize_weather_payload,
     parse_int,
     parse_number,
 )
+
+
+def test_enrich_weather_context_prefers_canonical_city_coordinates():
+    reading = {
+        "status": "success",
+        "coordenadas": {"lat": 1, "lon": 2},
+    }
+    expected_context = {"status": "success", "weather_provider": "open-meteo"}
+
+    with patch("weather_context.fetch_weather_context", return_value=expected_context) as fetcher:
+        result = enrich_with_weather_context(reading, canonical_lat=25.67, canonical_lon=-100.31)
+
+    assert result["weather_context"] == expected_context
+    fetcher.assert_called_once_with(25.67, -100.31)
+
+
+def test_enrich_weather_context_falls_back_to_reading_coordinates():
+    reading = {
+        "status": "success",
+        "coordenadas": {"lat": 25.67, "lon": -100.31},
+    }
+    expected_context = {"status": "success", "weather_provider": "open-meteo"}
+
+    with patch("weather_context.fetch_weather_context", return_value=expected_context) as fetcher:
+        result = enrich_with_weather_context(reading)
+
+    assert result["weather_context"] == expected_context
+    fetcher.assert_called_once_with(25.67, -100.31)
 
 
 def test_normalize_weather_payload_success():

--- a/weather_context.py
+++ b/weather_context.py
@@ -17,12 +17,23 @@ CURRENT_FIELDS = (
 )
 
 
-def enrich_with_weather_context(reading: dict[str, Any]) -> dict[str, Any]:
+def enrich_with_weather_context(
+    reading: dict[str, Any],
+    canonical_lat: Any = None,
+    canonical_lon: Any = None,
+) -> dict[str, Any]:
     if reading.get("status") != "success":
         return reading
 
-    coordinates = reading.get("coordenadas") if isinstance(reading.get("coordenadas"), dict) else {}
-    context = fetch_weather_context(coordinates.get("lat"), coordinates.get("lon"))
+    reading_coordinates = (
+        reading.get("coordenadas")
+        if isinstance(reading.get("coordenadas"), dict)
+        else {}
+    )
+    lat = canonical_lat if parse_number(canonical_lat) is not None else reading_coordinates.get("lat")
+    lon = canonical_lon if parse_number(canonical_lon) is not None else reading_coordinates.get("lon")
+
+    context = fetch_weather_context(lat, lon)
     return {**reading, "weather_context": context}
 
 


### PR DESCRIPTION
## Summary

Improves Open-Meteo weather enrichment coverage by using canonical city coordinates from Supabase as the primary coordinate source.

## Evidence

Read-only Supabase check showed latest rows with `weather_provider = open-meteo` for only part of the active municipalities. All active cities have canonical `latitude` and `longitude` in `public.cities`, so the write-path should use those coordinates instead of depending primarily on WAQI station coordinates.

## What changed

- `weather_context.enrich_with_weather_context` now accepts optional canonical city coordinates.
- `main.py` passes `city.latitude` and `city.longitude` into weather enrichment.
- Falls back to provider reading coordinates only if canonical coordinates are missing/invalid.
- Added tests for canonical coordinate preference and fallback behavior.

## Boundaries

- No Supabase DDL.
- No backfill.
- No RPC changes.
- No frontend changes.
- No provider AQI changes.
- No workflow schedule changes.

## Validation performed

- Compared `main...weather-coords`.
- Confirmed changed files are limited to:
  - `main.py`
  - `weather_context.py`
  - `tests/test_weather_context.py`

## Area touched

Pipeline weather enrichment only.

## Risks / pending items

- CI should run tests.
- After merge, observe the next forced or scheduled run and verify all active municipalities receive `weather_provider = open-meteo` on their latest rows.
- If Open-Meteo has transient failures, weather remains non-blocking and AQI inserts should continue.

## Rollback

Revert this PR. DB schema and frontend can remain unchanged.