### PR TITLE
docs: add weather context live coverage evidence

### DIFF
--- a/docs/weather-context-live-coverage-evidence.md
+++ b/docs/weather-context-live-coverage-evidence.md
@@ -1,36 +1,32 @@
 # Weather Context Live Coverage Evidence — MtyRespira
 
-Status: complete RPC-aligned follow-up live coverage evidence  
+Status: complete RPC-output follow-up live coverage evidence  
 Scope: `elelier/airquality_pipeline`  
 Target DB: `monterrey-respira-db` (`xjekikweaiddfwjjaqbd`)  
 Initial review timestamp: 2026-05-26 08:20 UTC  
-RPC-aligned follow-up review timestamp: 2026-05-29 14:45 UTC  
+RPC-output follow-up review timestamp: 2026-05-29 15:35 UTC  
 Decision type: Data QA / Architecture validation / Docs
 
 ## Summary
 
 Initial evidence from `2026-05-26 04:55..04:57 UTC` showed partial canonical Open-Meteo coverage: 5 of 9 latest active-city readings had complete weather context. Those rows were after PR #26 and before PR #27, so they validated post-coordinate-fix behavior but not post-PR-27 retry behavior.
 
-The follow-up evidence now uses a single RPC-aligned query pattern that:
+Follow-up evidence now uses the actual production public contract: `public.get_latest_air_quality_per_city()`.
 
-- starts from active `cities`,
-- uses `left join lateral` to keep active cities visible even if they have no reading,
-- selects each city's latest reading by `reading_timestamp desc`,
-- uses `created_at desc` only as a deterministic tie-breaker,
-- uses the same `latest` CTE for the aggregate and detail table.
+This avoids selecting rows with a documentary approximation of the RPC order. A prior evidence query added `created_at desc` and `NULLS LAST` as deterministic tie-breakers, but the RPC itself ranks rows only by `reading_timestamp desc`. For RPC/frontend readiness evidence, the safest docs-only validation is to inspect the RPC output directly.
 
-Decision: **initial evidence was partial; RPC-aligned follow-up evidence confirms complete 9/9 canonical Open-Meteo coverage.**
+Decision: **initial evidence was partial; direct RPC-output follow-up evidence confirms complete 9/9 canonical Open-Meteo coverage.**
 
 ## Result summary
 
-| Metric | Initial result | RPC-aligned follow-up result |
+| Metric | Initial result | Direct RPC-output follow-up result |
 | --- | ---: | ---: |
 | Active cities checked | 9 | 9 |
-| Active cities with latest reading | 9 | 9 |
-| Latest readings with AQI | 9 | 9 |
-| Latest readings with `weather_provider = 'open-meteo'` | 5 | 9 |
-| Latest readings with complete core weather context | 5 | 9 |
-| Active cities missing canonical weather context | 4 | 0 |
+| RPC rows returned | n/a | 9 |
+| Rows with AQI | 9 | 9 |
+| Rows with `weather_provider = 'open-meteo'` | 5 | 9 |
+| Rows with complete core weather context | 5 | 9 |
+| Active/RPC row count mismatch | n/a | 0 |
 
 ## Production RPC freshness contract
 
@@ -43,107 +39,103 @@ row_number() over (
 ) as rn
 ```
 
-The evidence query mirrors that public contract and adds `created_at desc` only as a tie-breaker.
+Because the frontend consumes this RPC, this evidence validates the RPC output directly instead of using a separate latest-row query with additional tie-breakers.
 
-## Read-only RPC-aligned evidence query
+## Read-only direct RPC-output summary query
 
 ```sql
-with latest as (
-  select
-    c.id as city_id,
-    c.name as city_name,
-    lr.created_at,
-    lr.reading_timestamp,
-    lr.aqi_us,
-    lr.main_pollutant_us,
-    lr.weather_provider,
-    lr.weather_temperature_c,
-    lr.weather_humidity_percent,
-    lr.weather_wind_speed_kmh,
-    lr.weather_wind_direction_deg,
-    lr.weather_wind_gust_kmh,
-    lr.weather_timestamp
-  from public.cities c
-  left join lateral (
-    select
-      r.created_at,
-      r.reading_timestamp,
-      r.aqi_us,
-      r.main_pollutant_us,
-      r.weather_provider,
-      r.weather_temperature_c,
-      r.weather_humidity_percent,
-      r.weather_wind_speed_kmh,
-      r.weather_wind_direction_deg,
-      r.weather_wind_gust_kmh,
-      r.weather_timestamp
-    from public.air_quality_readings r
-    where r.city_id = c.id
-    order by r.reading_timestamp desc nulls last, r.created_at desc nulls last
-    limit 1
-  ) lr on true
-  where c.is_active = true
+with rpc_rows as (
+  select *
+  from public.get_latest_air_quality_per_city()
+), active_cities as (
+  select count(*) as active_cities
+  from public.cities
+  where is_active = true
 )
 select
-  count(*) as active_cities,
-  count(*) filter (where reading_timestamp is not null) as active_cities_with_latest_reading,
-  count(*) filter (where aqi_us is not null) as latest_readings_with_aqi,
-  count(*) filter (where weather_provider = 'open-meteo') as latest_readings_with_open_meteo,
+  ac.active_cities,
+  count(*) as rpc_rows,
+  count(*) filter (where aqi_us is not null) as rpc_rows_with_aqi,
+  count(*) filter (where weather_provider = 'open-meteo') as rpc_rows_with_open_meteo,
   count(*) filter (
     where weather_provider = 'open-meteo'
       and weather_temperature_c is not null
       and weather_humidity_percent is not null
       and weather_wind_speed_kmh is not null
       and weather_timestamp is not null
-  ) as latest_readings_with_complete_core_weather,
+  ) as rpc_rows_with_complete_core_weather,
   max(reading_timestamp) as newest_reading_timestamp,
-  min(reading_timestamp) as oldest_latest_reading_timestamp,
-  max(created_at) as newest_created_at,
-  min(created_at) as oldest_latest_created_at
-from latest;
+  min(reading_timestamp) as oldest_latest_reading_timestamp
+from rpc_rows rr
+cross join active_cities ac
+group by ac.active_cities;
 ```
 
-RPC-aligned follow-up aggregate result:
+Direct RPC-output follow-up aggregate result:
 
 ```json
 [
   {
     "active_cities": 9,
-    "active_cities_with_latest_reading": 9,
-    "latest_readings_with_aqi": 9,
-    "latest_readings_with_open_meteo": 9,
-    "latest_readings_with_complete_core_weather": 9,
+    "rpc_rows": 9,
+    "rpc_rows_with_aqi": 9,
+    "rpc_rows_with_open_meteo": 9,
+    "rpc_rows_with_complete_core_weather": 9,
     "newest_reading_timestamp": "2026-05-29 13:00:00+00",
-    "oldest_latest_reading_timestamp": "2026-05-29 12:00:00+00",
-    "newest_created_at": "2026-05-29 14:36:43.815507+00",
-    "oldest_latest_created_at": "2026-05-29 14:34:52.144581+00"
+    "oldest_latest_reading_timestamp": "2026-05-29 12:00:00+00"
   }
 ]
 ```
 
-## Follow-up detail rows — 2026-05-29, RPC-aligned
+## Direct RPC-output detail rows — 2026-05-29
 
-| City | Created at UTC | Reading timestamp UTC | AQI | Main pollutant | Weather provider | Temperature C | Humidity % | Wind km/h | Wind direction deg | Gust km/h | Weather timestamp UTC | Core weather fields |
-| --- | --- | --- | ---: | --- | --- | ---: | ---: | ---: | ---: | ---: | --- | --- |
-| Cadereyta Jimenez | 2026-05-29 14:36:43 | 2026-05-29 12:00:00 | 21 | `pm25` | `open-meteo` | 25.4 | 81 | 4.9 | 107 | 10.8 | 2026-05-29 14:30:00 | complete |
-| Ciudad Benito Juárez | 2026-05-29 14:35:02 | 2026-05-29 12:00:00 | 21 | `pm10` | `open-meteo` | 25.2 | 84 | 4.7 | 113 | 11.2 | 2026-05-29 14:30:00 | complete |
-| Garcia | 2026-05-29 14:34:52 | 2026-05-29 12:00:00 | 52 | `pm25` | `open-meteo` | 25.0 | 76 | 4.1 | 135 | 4.3 | 2026-05-29 14:30:00 | complete |
-| General Escobedo | 2026-05-29 14:35:57 | 2026-05-29 12:00:00 | 56 | `pm25` | `open-meteo` | 24.3 | 86 | 4.2 | 70 | 9.0 | 2026-05-29 14:30:00 | complete |
-| Guadalupe | 2026-05-29 14:35:12 | 2026-05-29 12:00:00 | 22 | `pm10` | `open-meteo` | 25.4 | 82 | 4.7 | 81 | 10.8 | 2026-05-29 14:30:00 | complete |
-| Monterrey | 2026-05-29 14:35:33 | 2026-05-29 12:00:00 | 49 | `pm25` | `open-meteo` | 24.6 | 83 | 2.9 | 30 | 6.5 | 2026-05-29 14:30:00 | complete |
-| San Nicolas de los Garza | 2026-05-29 14:36:18 | 2026-05-29 13:00:00 | 54 | `pm25` | `open-meteo` | 24.7 | 84 | 2.7 | 23 | 8.6 | 2026-05-29 14:30:00 | complete |
-| San Pedro Garza Garcia | 2026-05-29 14:35:23 | 2026-05-29 12:00:00 | 16 | `o3` | `open-meteo` | 25.0 | 78 | 2.5 | 82 | 3.6 | 2026-05-29 14:30:00 | complete |
-| Santa Catarina | 2026-05-29 14:36:08 | 2026-05-29 13:00:00 | 42 | `pm25` | `open-meteo` | 25.3 | 80 | 7.6 | 177 | 7.6 | 2026-05-29 14:30:00 | complete |
+```sql
+select
+  city_name,
+  reading_timestamp,
+  aqi_us,
+  main_pollutant_us,
+  weather_provider,
+  weather_temperature_c,
+  weather_humidity_percent,
+  weather_wind_speed_kmh,
+  weather_wind_direction_deg,
+  weather_wind_gust_kmh,
+  weather_timestamp
+from public.get_latest_air_quality_per_city()
+order by city_name asc;
+```
 
-RPC-aligned follow-up cities missing canonical weather context on latest reading: **none**.
+| City | Reading timestamp UTC | AQI | Main pollutant | Weather provider | Temperature C | Humidity % | Wind km/h | Wind direction deg | Gust km/h | Weather timestamp UTC | Core weather fields |
+| --- | --- | ---: | --- | --- | ---: | ---: | ---: | ---: | ---: | --- | --- |
+| Cadereyta Jimenez | 2026-05-29 12:00:00 | 21 | `pm25` | `open-meteo` | 25.4 | 81 | 4.9 | 107 | 10.8 | 2026-05-29 14:30:00 | complete |
+| Ciudad Benito Juárez | 2026-05-29 12:00:00 | 21 | `pm10` | `open-meteo` | 25.2 | 84 | 4.7 | 113 | 11.2 | 2026-05-29 14:30:00 | complete |
+| Garcia | 2026-05-29 12:00:00 | 52 | `pm25` | `open-meteo` | 25.0 | 76 | 4.1 | 135 | 4.3 | 2026-05-29 14:30:00 | complete |
+| General Escobedo | 2026-05-29 12:00:00 | 56 | `pm25` | `open-meteo` | 24.3 | 86 | 4.2 | 70 | 9.0 | 2026-05-29 14:30:00 | complete |
+| Guadalupe | 2026-05-29 12:00:00 | 22 | `pm10` | `open-meteo` | 25.4 | 82 | 4.7 | 81 | 10.8 | 2026-05-29 14:30:00 | complete |
+| Monterrey | 2026-05-29 12:00:00 | 49 | `pm25` | `open-meteo` | 24.6 | 83 | 2.9 | 30 | 6.5 | 2026-05-29 14:30:00 | complete |
+| San Nicolas de los Garza | 2026-05-29 13:00:00 | 54 | `pm25` | `open-meteo` | 24.7 | 84 | 2.7 | 23 | 8.6 | 2026-05-29 14:30:00 | complete |
+| San Pedro Garza Garcia | 2026-05-29 12:00:00 | 16 | `o3` | `open-meteo` | 25.0 | 78 | 2.5 | 82 | 3.6 | 2026-05-29 14:30:00 | complete |
+| Santa Catarina | 2026-05-29 13:00:00 | 42 | `pm25` | `open-meteo` | 25.3 | 80 | 7.6 | 177 | 7.6 | 2026-05-29 14:30:00 | complete |
+
+Direct RPC-output rows missing canonical weather context: **none**.
+
+## Duplicate latest timestamp check
+
+The P1 review noted that duplicate provider timestamps could make a documentary query with tie-breakers select a different row from the RPC. Current evidence therefore uses the RPC output directly.
+
+As an additional read-only diagnostic, the current dataset was checked for duplicate rows at recent latest timestamps. No duplicate rows were found for active-city readings at or after `2026-05-29 12:00:00+00`.
 
 ## Review comment resolution
 
-Resolved P2 `Reconcile the follow-up aggregate with the detail rows` by regenerating the aggregate and detail table from the same `latest` CTE and evidence window.
+Resolved P1 `Preserve the RPC's actual row ordering` by removing documentary reliance on `created_at desc` / `NULLS LAST` tie-breakers for readiness evidence and validating the output of `public.get_latest_air_quality_per_city()` directly.
 
-Resolved P2 `Count active cities from the cities table` by changing the evidence query to start from active `cities` and use `left join lateral`, so an active city with no reading would still be counted in `active_cities` but not in `active_cities_with_latest_reading`.
+Previously resolved P2 comments remain addressed:
 
-Previously resolved P2 `Match the evidence query to the RPC freshness order` remains addressed by the `reading_timestamp desc` selection.
+- Initial timing is documented as post-PR #26 / pre-PR #27.
+- The evidence now validates the public RPC output directly.
+- Active cities are counted from `public.cities` and compared against RPC row count.
+- Aggregate and detail rows are both generated from the direct RPC output.
 
 ## No-write guarantees
 
@@ -153,17 +145,17 @@ No AQI, `main_pollutant_us`, historical AQI, city identity, geolocation, or publ
 
 ## Validation performed
 
-- Ran read-only Supabase RPC-aligned summary evidence query.
-- Ran read-only Supabase RPC-aligned details query using the same `latest` CTE shape.
-- Confirmed 9 active cities.
-- Confirmed 9/9 latest active-city readings with AQI.
-- Confirmed 9/9 latest active-city readings with `weather_provider = 'open-meteo'`.
-- Confirmed 9/9 latest active-city readings with complete core weather context.
-- Confirmed aggregate/detail consistency:
-  - oldest latest `reading_timestamp`: `2026-05-29 12:00:00+00`
-  - newest latest `reading_timestamp`: `2026-05-29 13:00:00+00`
-  - oldest latest `created_at`: `2026-05-29 14:34:52.144581+00`
-  - newest latest `created_at`: `2026-05-29 14:36:43.815507+00`
+- Reviewed current PR #28 state.
+- Reviewed the P1 review thread.
+- Reviewed the migration defining `get_latest_air_quality_per_city` and confirmed the RPC freshness order is `reading_timestamp desc` only.
+- Ran read-only `public.get_latest_air_quality_per_city()` aggregate evidence query.
+- Ran read-only `public.get_latest_air_quality_per_city()` detail evidence query.
+- Ran read-only active-city count query.
+- Ran read-only recent duplicate timestamp diagnostic.
+- Confirmed 9 active cities and 9 RPC rows.
+- Confirmed 9/9 RPC rows with AQI.
+- Confirmed 9/9 RPC rows with `weather_provider = 'open-meteo'`.
+- Confirmed 9/9 RPC rows with complete core weather context.
 - Confirmed this PR remains docs-only.
 - Confirmed no runtime files, workflow files, frontend files, or DB migrations were modified.
 

--- a/docs/weather-context-live-coverage-evidence.md
+++ b/docs/weather-context-live-coverage-evidence.md
@@ -9,19 +9,19 @@ Decision type: Data QA / Architecture validation / Docs
 
 ## Summary
 
-This document records read-only live evidence for canonical Open-Meteo weather-context coverage after:
+Initial evidence from `2026-05-26 04:55..04:57 UTC` showed partial canonical Open-Meteo coverage: 5 of 9 latest active-city readings had complete weather context. Those rows were after PR #26 and before PR #27, so they validated post-coordinate-fix behavior but not post-PR-27 retry behavior.
 
-- PR #23: `feat: add Open-Meteo weather context write path`
-- PR #26: `fix: use canonical city coordinates for weather context`
-- PR #27: `fix: improve retry handling`
+The follow-up evidence now uses a single RPC-aligned query pattern that:
 
-Initial evidence captured from latest active-city readings created around `2026-05-26 04:55..04:57 UTC` showed partial coverage: 5 of 9 latest active-city readings had canonical Open-Meteo context. Those rows were after PR #26 merged and before PR #27 merged, so they confirmed post-coordinate-fix coverage but did not validate post-PR-27 retry behavior.
+- starts from active `cities`,
+- uses `left join lateral` to keep active cities visible even if they have no reading,
+- selects each city's latest reading by `reading_timestamp desc`,
+- uses `created_at desc` only as a deterministic tie-breaker,
+- uses the same `latest` CTE for the aggregate and detail table.
 
-A follow-up on `2026-05-29` originally used insertion order. Review feedback correctly noted that evidence intended to support RPC/frontend readiness must mirror the production `get_latest_air_quality_per_city` freshness order.
+Decision: **initial evidence was partial; RPC-aligned follow-up evidence confirms complete 9/9 canonical Open-Meteo coverage.**
 
-This document now uses RPC-aligned evidence: latest rows are selected by `reading_timestamp desc`, with `created_at desc` only as a deterministic tie-breaker for evidence stability. The RPC-aligned follow-up confirms complete canonical Open-Meteo coverage across all active cities.
-
-Result summary:
+## Result summary
 
 | Metric | Initial result | RPC-aligned follow-up result |
 | --- | ---: | ---: |
@@ -31,29 +31,6 @@ Result summary:
 | Latest readings with `weather_provider = 'open-meteo'` | 5 | 9 |
 | Latest readings with complete core weather context | 5 | 9 |
 | Active cities missing canonical weather context | 4 | 0 |
-
-Decision: **initial evidence was partial; RPC-aligned follow-up evidence confirms complete 9/9 canonical Open-Meteo coverage.**
-
-## Scope
-
-This story is evidence-only.
-
-It does not change:
-
-- Supabase schema,
-- data rows,
-- backfill state,
-- runtime pipeline code,
-- WAQI/AQICN provider behavior,
-- RPCs,
-- frontend code,
-- workflow schedule,
-- AQI values,
-- `main_pollutant_us`,
-- historical AQI,
-- city identity,
-- city geolocation,
-- public frontend contract.
 
 ## Production RPC freshness contract
 
@@ -66,18 +43,29 @@ row_number() over (
 ) as rn
 ```
 
-Because the frontend consumes this RPC, coverage evidence must validate the same row set the public contract exposes. The evidence query therefore selects one latest row per active city using `reading_timestamp desc`; `created_at desc` is used only as a deterministic tie-breaker for the evidence query.
+The evidence query mirrors that public contract and adds `created_at desc` only as a tie-breaker.
 
-## Read-only RPC-aligned summary query
+## Read-only RPC-aligned evidence query
 
 ```sql
 with latest as (
-  select *
-  from (
+  select
+    c.id as city_id,
+    c.name as city_name,
+    lr.created_at,
+    lr.reading_timestamp,
+    lr.aqi_us,
+    lr.main_pollutant_us,
+    lr.weather_provider,
+    lr.weather_temperature_c,
+    lr.weather_humidity_percent,
+    lr.weather_wind_speed_kmh,
+    lr.weather_wind_direction_deg,
+    lr.weather_wind_gust_kmh,
+    lr.weather_timestamp
+  from public.cities c
+  left join lateral (
     select
-      c.id as city_id,
-      c.name as city_name,
-      r.id as reading_id,
       r.created_at,
       r.reading_timestamp,
       r.aqi_us,
@@ -88,20 +76,17 @@ with latest as (
       r.weather_wind_speed_kmh,
       r.weather_wind_direction_deg,
       r.weather_wind_gust_kmh,
-      r.weather_timestamp,
-      row_number() over (
-        partition by r.city_id
-        order by r.reading_timestamp desc, r.created_at desc
-      ) as rn
+      r.weather_timestamp
     from public.air_quality_readings r
-    join public.cities c on r.city_id = c.id
-    where c.is_active = true
-  ) ranked
-  where rn = 1
+    where r.city_id = c.id
+    order by r.reading_timestamp desc nulls last, r.created_at desc nulls last
+    limit 1
+  ) lr on true
+  where c.is_active = true
 )
 select
   count(*) as active_cities,
-  count(*) filter (where reading_id is not null) as active_cities_with_latest_reading,
+  count(*) filter (where reading_timestamp is not null) as active_cities_with_latest_reading,
   count(*) filter (where aqi_us is not null) as latest_readings_with_aqi,
   count(*) filter (where weather_provider = 'open-meteo') as latest_readings_with_open_meteo,
   count(*) filter (
@@ -118,7 +103,7 @@ select
 from latest;
 ```
 
-RPC-aligned follow-up result:
+RPC-aligned follow-up aggregate result:
 
 ```json
 [
@@ -129,30 +114,14 @@ RPC-aligned follow-up result:
     "latest_readings_with_open_meteo": 9,
     "latest_readings_with_complete_core_weather": 9,
     "newest_reading_timestamp": "2026-05-29 13:00:00+00",
-    "oldest_latest_reading_timestamp": "2026-05-29 08:00:00+00",
-    "newest_created_at": "2026-05-29 14:36:18.822865+00",
-    "oldest_latest_created_at": "2026-05-29 11:20:50.860009+00"
+    "oldest_latest_reading_timestamp": "2026-05-29 12:00:00+00",
+    "newest_created_at": "2026-05-29 14:36:43.815507+00",
+    "oldest_latest_created_at": "2026-05-29 14:34:52.144581+00"
   }
 ]
 ```
 
-## Initial coverage by city — 2026-05-26
-
-| City | Created at UTC | AQI | Main pollutant | Weather provider | Core weather fields |
-| --- | --- | ---: | --- | --- | --- |
-| Cadereyta Jimenez | 2026-05-26 04:56:32 | 55 | `pm25` | null | missing |
-| Ciudad Benito Juárez | 2026-05-26 04:57:03 | 55 | `pm25` | null | missing |
-| Garcia | 2026-05-26 04:56:42 | 33 | `pm25` | `open-meteo` | complete |
-| General Escobedo | 2026-05-26 04:57:55 | 46 | `pm25` | `open-meteo` | complete |
-| Guadalupe | 2026-05-26 04:57:13 | 31 | `o3` | `open-meteo` | complete |
-| Monterrey | 2026-05-26 04:57:45 | 34 | `pm25` | null | missing |
-| San Nicolas de los Garza | 2026-05-26 04:56:11 | 58 | `pm25` | null | missing |
-| San Pedro Garza Garcia | 2026-05-26 04:57:24 | 46 | `pm25` | `open-meteo` | complete |
-| Santa Catarina | 2026-05-26 04:55:50 | 42 | `pm25` | `open-meteo` | complete |
-
-## Follow-up evidence — 2026-05-29, RPC-aligned
-
-Follow-up coverage by city using `reading_timestamp desc`, with `created_at desc` as tie-breaker:
+## Follow-up detail rows — 2026-05-29, RPC-aligned
 
 | City | Created at UTC | Reading timestamp UTC | AQI | Main pollutant | Weather provider | Temperature C | Humidity % | Wind km/h | Wind direction deg | Gust km/h | Weather timestamp UTC | Core weather fields |
 | --- | --- | --- | ---: | --- | --- | ---: | ---: | ---: | ---: | ---: | --- | --- |
@@ -168,100 +137,38 @@ Follow-up coverage by city using `reading_timestamp desc`, with `created_at desc
 
 RPC-aligned follow-up cities missing canonical weather context on latest reading: **none**.
 
-## AQI safety check
-
-All 9 active cities have a latest reading with non-null AQI in both the initial and RPC-aligned follow-up evidence sets.
-
-This supports the intended behavior that weather context remains separate from AQI and does not block successful AQI inserts.
-
-No AQI rewrite or pollutant rewrite was performed by this evidence story.
-
-## Weather context completeness
-
-Initial evidence showed canonical Open-Meteo weather context on 5 of 9 latest active-city readings.
-
-RPC-aligned follow-up evidence shows canonical Open-Meteo weather context on 9 of 9 latest active-city readings, including these core canonical fields:
-
-- `weather_temperature_c`
-- `weather_humidity_percent`
-- `weather_wind_speed_kmh`
-- `weather_timestamp`
-
-## Decision
-
-**Initial evidence was partial; RPC-aligned follow-up evidence confirms complete 9/9 canonical Open-Meteo coverage.**
-
-This evidence supports treating the missing-city coverage gap observed on `2026-05-26` as superseded by the `2026-05-29` read-only RPC-aligned follow-up snapshot.
-
-This documentation update does not authorize frontend adoption, backfill, RPC changes, workflow changes, or runtime changes by itself. Those should remain separate stories with their own validation gates.
-
 ## Review comment resolution
 
-Resolved P2 `Match the evidence query to the RPC freshness order` by changing the evidence selection from `created_at desc` to an RPC-aligned `reading_timestamp desc` order, with `created_at desc` retained only as a deterministic tie-breaker for evidence reproducibility.
+Resolved P2 `Reconcile the follow-up aggregate with the detail rows` by regenerating the aggregate and detail table from the same `latest` CTE and evidence window.
 
-The recaptured read-only evidence still confirms 9/9 canonical Open-Meteo coverage for the rows the frontend/RPC contract would expose.
+Resolved P2 `Count active cities from the cities table` by changing the evidence query to start from active `cities` and use `left join lateral`, so an active city with no reading would still be counted in `active_cities` but not in `active_cities_with_latest_reading`.
 
-## Recommended next step
-
-Use this complete-coverage evidence as an input for the next small gated story, likely one of:
-
-```text
-Story 1.4.11 — Weather Context RPC Contract Verification
-```
-
-or
-
-```text
-Story 1.4.11 — Weather Context Frontend Adoption Readiness
-```
-
-Suggested scope for the next story:
-
-- Verify the RPC/public contract path exposes only intended weather fields.
-- Confirm UI adoption remains explicit, guarded, and truthful.
-- Avoid backfill, DDL, workflow, AQI provider, or frontend changes unless specifically scoped.
+Previously resolved P2 `Match the evidence query to the RPC freshness order` remains addressed by the `reading_timestamp desc` selection.
 
 ## No-write guarantees
 
-This story did not perform:
+This story did not perform Supabase DDL, Supabase data mutation, backfill, runtime code changes, workflow schedule changes, RPC changes, frontend changes, AQI provider changes, or secret exposure.
 
-- Supabase DDL,
-- Supabase data mutation,
-- backfill,
-- runtime code changes,
-- workflow schedule changes,
-- RPC changes,
-- frontend changes,
-- AQI provider changes,
-- secret exposure.
-
-No secret assignment patterns were added for WAQI, AirVisual, or Supabase service-role credentials.
-
-No service-role guidance was added for frontend/app usage.
+No AQI, `main_pollutant_us`, historical AQI, city identity, geolocation, or public frontend contract values were changed.
 
 ## Validation performed
 
-- Reviewed current PR #28 state.
-- Reviewed current `docs/weather-context-live-coverage-evidence.md` from branch `docs/story-1-4-10-weather-live-coverage-evidence`.
-- Reviewed the migration defining `get_latest_air_quality_per_city` and confirmed the RPC freshness order is `reading_timestamp desc`.
-- Updated the evidence query to mirror the RPC freshness order.
-- Ran read-only Supabase RPC-aligned summary evidence query only.
-- Ran read-only Supabase RPC-aligned latest active-city details query only.
-- Confirmed follow-up evidence output shows 9 active cities.
-- Confirmed follow-up evidence output shows 9/9 RPC-selected latest active-city readings with AQI.
-- Confirmed follow-up evidence output shows 9/9 RPC-selected latest active-city readings with `weather_provider = 'open-meteo'`.
-- Confirmed follow-up evidence output shows 9/9 RPC-selected latest active-city readings with complete core weather context.
+- Ran read-only Supabase RPC-aligned summary evidence query.
+- Ran read-only Supabase RPC-aligned details query using the same `latest` CTE shape.
+- Confirmed 9 active cities.
+- Confirmed 9/9 latest active-city readings with AQI.
+- Confirmed 9/9 latest active-city readings with `weather_provider = 'open-meteo'`.
+- Confirmed 9/9 latest active-city readings with complete core weather context.
+- Confirmed aggregate/detail consistency:
+  - oldest latest `reading_timestamp`: `2026-05-29 12:00:00+00`
+  - newest latest `reading_timestamp`: `2026-05-29 13:00:00+00`
+  - oldest latest `created_at`: `2026-05-29 14:34:52.144581+00`
+  - newest latest `created_at`: `2026-05-29 14:36:43.815507+00`
 - Confirmed this PR remains docs-only.
-- Confirmed no runtime files were modified.
-- Confirmed no workflow schedule files were modified.
-- Confirmed no DDL was executed.
-- Confirmed no backfill was performed.
-- Confirmed AQI, `main_pollutant_us`, historical AQI, city identity, geolocation, and public frontend contract were not changed.
+- Confirmed no runtime files, workflow files, frontend files, or DB migrations were modified.
 
 ## Rollback
 
 Revert this documentation PR.
 
-No database rollback is required because this story is read-only evidence documentation.
-
-No runtime, Cloudflare, workflow, RPC, frontend, AQI, or provider rollback is required.
+No database, runtime, Cloudflare, workflow, RPC, frontend, AQI, or provider rollback is required.

--- a/docs/weather-context-live-coverage-evidence.md
+++ b/docs/weather-context-live-coverage-evidence.md
@@ -1,9 +1,10 @@
 # Weather Context Live Coverage Evidence — MtyRespira
 
-Status: partial live coverage evidence  
+Status: complete follow-up live coverage evidence  
 Scope: `elelier/airquality_pipeline`  
 Target DB: `monterrey-respira-db` (`xjekikweaiddfwjjaqbd`)  
-Review timestamp: 2026-05-26 08:20 UTC  
+Initial review timestamp: 2026-05-26 08:20 UTC  
+Follow-up review timestamp: 2026-05-29 00:10 UTC  
 Decision type: Data QA / Architecture validation / Docs
 
 ## Summary
@@ -12,21 +13,24 @@ This document records read-only live evidence for canonical Open-Meteo weather-c
 
 - PR #23: `feat: add Open-Meteo weather context write path`
 - PR #26: `fix: use canonical city coordinates for weather context`
+- PR #27: `fix: improve retry handling`
 
-The captured latest active-city readings were created around `2026-05-26 04:55..04:57 UTC`, which is after PR #26 merged and before PR #27 (`fix: improve retry handling`) merged. This evidence confirms post-coordinate-fix coverage and AQI insert safety, but it does not validate post-PR-27 retry behavior. Weather context coverage is real but still partial.
+Initial evidence captured from latest active-city readings created around `2026-05-26 04:55..04:57 UTC` showed partial coverage: 5 of 9 latest active-city readings had canonical Open-Meteo context. Those rows were after PR #26 merged and before PR #27 merged, so they confirmed post-coordinate-fix coverage but did not validate post-PR-27 retry behavior.
+
+Follow-up evidence captured on `2026-05-29` from latest active-city readings created around `2026-05-29 00:00..00:02 UTC` confirms complete canonical Open-Meteo coverage across all active cities.
 
 Result summary:
 
-| Metric | Result |
-| --- | ---: |
-| Active cities checked | 9 |
-| Active cities with latest reading | 9 |
-| Latest readings with AQI | 9 |
-| Latest readings with `weather_provider = 'open-meteo'` | 5 |
-| Latest readings with complete core weather context | 5 |
-| Active cities missing canonical weather context | 4 |
+| Metric | Initial result | Follow-up result |
+| --- | ---: | ---: |
+| Active cities checked | 9 | 9 |
+| Active cities with latest reading | 9 | 9 |
+| Latest readings with AQI | 9 | 9 |
+| Latest readings with `weather_provider = 'open-meteo'` | 5 | 9 |
+| Latest readings with complete core weather context | 5 | 9 |
+| Active cities missing canonical weather context | 4 | 0 |
 
-Decision: **partial coverage — investigate missing weather context by city before frontend adoption or backfill.**
+Decision: **initial evidence was partial; follow-up evidence confirms complete 9/9 canonical Open-Meteo coverage.**
 
 ## Scope
 
@@ -57,7 +61,7 @@ The evidence checks the latest reading for each active city and asks:
 2. Does every latest reading still have AQI?
 3. Which latest readings include canonical Open-Meteo fields?
 4. Which cities are still missing canonical weather context?
-5. Do the latest rows fall after PR #26 and before PR #27, making this a coordinate-fix coverage check rather than a retry-fix validation check?
+5. Do follow-up latest rows confirm complete post-PR-27 Open-Meteo coverage?
 
 PR merge reference:
 
@@ -66,7 +70,9 @@ PR merge reference:
 | PR #26 | 2026-05-25 20:11:50 UTC |
 | PR #27 | 2026-05-26 07:25:52 UTC |
 
-The latest rows captured below were created around `2026-05-26 04:55..04:57 UTC`, which is after PR #26 but before PR #27. Therefore this evidence confirms post-coordinate-fix coverage, but not yet a post-PR-27 scheduled insert. The retry fix should still be verified on a later post-PR-27 run if retry behavior is specifically under review.
+The initial rows captured below were created around `2026-05-26 04:55..04:57 UTC`, which is after PR #26 but before PR #27. Therefore the initial evidence confirmed post-coordinate-fix coverage, but not a post-PR-27 scheduled insert.
+
+The follow-up rows captured below were created around `2026-05-29 00:00..00:02 UTC`, which is after PR #27. Therefore this follow-up evidence confirms complete current canonical Open-Meteo coverage for latest active-city readings.
 
 ## Read-only summary query
 
@@ -110,7 +116,7 @@ select
 from latest;
 ```
 
-Result:
+Initial result:
 
 ```json
 [
@@ -126,7 +132,7 @@ Result:
 ]
 ```
 
-## Coverage by city
+## Initial coverage by city — 2026-05-26
 
 | City | Created at UTC | AQI | Main pollutant | Weather provider | Core weather fields |
 | --- | --- | ---: | --- | --- | --- |
@@ -140,7 +146,7 @@ Result:
 | San Pedro Garza Garcia | 2026-05-26 04:57:24 | 46 | `pm25` | `open-meteo` | complete |
 | Santa Catarina | 2026-05-26 04:55:50 | 42 | `pm25` | `open-meteo` | complete |
 
-Cities with complete canonical weather context:
+Initial cities with complete canonical weather context:
 
 - Garcia
 - General Escobedo
@@ -148,87 +154,105 @@ Cities with complete canonical weather context:
 - San Pedro Garza Garcia
 - Santa Catarina
 
-Cities still missing canonical weather context on latest reading:
+Initial cities missing canonical weather context on latest reading:
 
 - Cadereyta Jimenez
 - Ciudad Benito Juárez
 - Monterrey
 - San Nicolas de los Garza
 
+## Follow-up evidence — 2026-05-29
+
+Read-only summary result:
+
+```json
+[
+  {
+    "active_cities": 9,
+    "active_cities_with_latest_reading": 9,
+    "latest_readings_with_aqi": 9,
+    "latest_readings_with_open_meteo": 9,
+    "latest_readings_with_complete_core_weather": 9,
+    "newest_created_at": "2026-05-29 00:02:41.016918+00",
+    "oldest_latest_created_at": "2026-05-29 00:00:24.009169+00"
+  }
+]
+```
+
+Follow-up coverage by city:
+
+| City | Created at UTC | Reading timestamp UTC | AQI | Main pollutant | Weather provider | Temperature C | Humidity % | Wind km/h | Wind direction deg | Gust km/h | Weather timestamp UTC | Core weather fields |
+| --- | --- | --- | ---: | --- | --- | ---: | ---: | ---: | ---: | ---: | --- | --- |
+| Cadereyta Jimenez | 2026-05-29 00:01:14 | 2026-05-28 22:00:00 | 42 | `pm25` | `open-meteo` | 31.6 | 51 | 15.3 | 117 | 20.9 | 2026-05-29 00:00:00 | complete |
+| Ciudad Benito Juárez | 2026-05-29 00:02:09 | 2026-05-28 22:00:00 | 28 | `o3` | `open-meteo` | 31.3 | 52 | 18.2 | 120 | 22.7 | 2026-05-29 00:00:00 | complete |
+| Garcia | 2026-05-29 00:01:24 | 2026-05-28 22:00:00 | 47 | `o3` | `open-meteo` | 30.1 | 50 | 30.9 | 107 | 38.9 | 2026-05-29 00:00:00 | complete |
+| General Escobedo | 2026-05-29 00:00:24 | 2026-05-28 22:00:00 | 55 | `pm25` | `open-meteo` | 31.1 | 50 | 20.0 | 116 | 27.4 | 2026-05-29 00:00:00 | complete |
+| Guadalupe | 2026-05-29 00:02:20 | 2026-05-28 21:00:00 | 30 | `o3` | `open-meteo` | 30.8 | 52 | 18.8 | 119 | 27.0 | 2026-05-29 00:00:00 | complete |
+| Monterrey | 2026-05-29 00:02:41 | 2026-05-28 22:00:00 | 45 | `pm25` | `open-meteo` | 30.5 | 51 | 19.1 | 106 | 26.6 | 2026-05-29 00:00:00 | complete |
+| San Nicolas de los Garza | 2026-05-29 00:01:03 | 2026-05-28 22:00:00 | 58 | `pm25` | `open-meteo` | 31.0 | 51 | 18.4 | 116 | 27.4 | 2026-05-29 00:00:00 | complete |
+| San Pedro Garza Garcia | 2026-05-29 00:02:30 | 2026-05-28 22:00:00 | 42 | `o3` | `open-meteo` | 30.2 | 51 | 21.1 | 99 | 29.5 | 2026-05-29 00:00:00 | complete |
+| Santa Catarina | 2026-05-29 00:00:52 | 2026-05-28 22:00:00 | 34 | `pm25` | `open-meteo` | 29.8 | 52 | 21.3 | 95 | 32.0 | 2026-05-29 00:00:00 | complete |
+
+Follow-up cities with complete canonical weather context:
+
+- Cadereyta Jimenez
+- Ciudad Benito Juárez
+- Garcia
+- General Escobedo
+- Guadalupe
+- Monterrey
+- San Nicolas de los Garza
+- San Pedro Garza Garcia
+- Santa Catarina
+
+Follow-up cities missing canonical weather context on latest reading: **none**.
+
 ## AQI safety check
 
-All 9 active cities have a latest reading with non-null AQI.
+All 9 active cities have a latest reading with non-null AQI in both the initial and follow-up evidence sets.
 
 This supports the intended behavior that weather context remains separate from AQI and does not block successful AQI inserts.
-
-Observed latest AQI values remain present across both groups:
-
-- Cities with Open-Meteo context: AQI values present.
-- Cities without Open-Meteo context: AQI values present.
 
 No AQI rewrite or pollutant rewrite was performed by this evidence story.
 
 ## Weather context completeness
 
-For the 5 latest readings with `weather_provider = 'open-meteo'`, the core canonical fields were present:
+Initial evidence showed canonical Open-Meteo weather context on 5 of 9 latest active-city readings.
+
+Follow-up evidence shows canonical Open-Meteo weather context on 9 of 9 latest active-city readings, including these core canonical fields:
 
 - `weather_temperature_c`
 - `weather_humidity_percent`
 - `weather_wind_speed_kmh`
 - `weather_timestamp`
 
-Observed complete-weather examples:
-
-| City | Temperature C | Humidity % | Wind km/h | Wind direction deg | Gust km/h | Weather timestamp UTC |
-| --- | ---: | ---: | ---: | ---: | ---: | --- |
-| Garcia | 24.5 | 73 | 29.2 | 86 | 48.6 | 2026-05-26 04:45:00 |
-| General Escobedo | 25.2 | 76 | 17.9 | 115 | 33.1 | 2026-05-26 04:45:00 |
-| Guadalupe | 25.0 | 76 | 17.6 | 125 | 33.5 | 2026-05-26 04:45:00 |
-| San Pedro Garza Garcia | 24.9 | 70 | 19.2 | 67 | 29.9 | 2026-05-26 04:45:00 |
-| Santa Catarina | 24.2 | 74 | 24.4 | 68 | 36.0 | 2026-05-26 04:45:00 |
-
-## Gaps / cities pending
-
-Coverage is not yet sufficient for frontend adoption because 4 of 9 active cities still have null canonical weather context on latest readings.
-
-Pending investigation should focus on why these cities inserted AQI successfully but did not persist weather context:
-
-- Cadereyta Jimenez
-- Ciudad Benito Juárez
-- Monterrey
-- San Nicolas de los Garza
-
-Likely investigation areas for a future runtime/debug story:
-
-- Confirm whether canonical `cities.latitude` and `cities.longitude` are present and parseable for each missing city.
-- Inspect pipeline logs for `[Weather]` errors on these cities.
-- Confirm whether Open-Meteo returned non-retryable client errors, retryable server errors, invalid payload, validation failure, or missing coordinates.
-- Confirm whether city coordinate updates from WAQI overwrite canonical city coordinates before weather enrichment or after insert.
-- Capture a post-PR-27 run to verify the retry handling fix under current production behavior.
-
 ## Decision
 
-**Partial coverage. Do not proceed directly to frontend adoption or weather backfill.**
+**Initial evidence was partial; follow-up evidence confirms complete 9/9 canonical Open-Meteo coverage.**
 
-Open-Meteo write path is working for some cities and AQI remains safe, but coverage is incomplete across active municipalities.
+This evidence supports treating the missing-city coverage gap observed on `2026-05-26` as superseded by the `2026-05-29` read-only follow-up snapshot.
+
+This documentation update does not authorize frontend adoption, backfill, RPC changes, workflow changes, or runtime changes by itself. Those should remain separate stories with their own validation gates.
 
 ## Recommended next step
 
-Create a small runtime/Data QA investigation story:
+Use this complete-coverage evidence as an input for the next small gated story, likely one of:
 
 ```text
-Story 1.4.11 — Weather Context Missing City Diagnostics
+Story 1.4.11 — Weather Context RPC Contract Verification
 ```
 
-Suggested scope:
+or
 
-- Read-only inspect active city coordinates for missing cities.
-- Review latest workflow logs for weather error types, without exposing secrets.
-- Add non-sensitive structured logging if current logs do not identify weather failure reason per city.
-- Add tests if a deterministic bug is found.
-- No backfill, no frontend, no DDL, no RPC changes until coverage is understood.
+```text
+Story 1.4.11 — Weather Context Frontend Adoption Readiness
+```
 
-If a post-PR-27 scheduled run later reaches 9/9 Open-Meteo coverage, this document can be superseded by a new coverage evidence note and the next step may shift to RPC live apply verification or frontend adoption.
+Suggested scope for the next story:
+
+- Verify the RPC/public contract path exposes only intended weather fields.
+- Confirm UI adoption remains explicit, guarded, and truthful.
+- Avoid backfill, DDL, workflow, AQI provider, or frontend changes unless specifically scoped.
 
 ## No-write guarantees
 
@@ -250,11 +274,15 @@ No service-role guidance was added for frontend/app usage.
 
 ## Validation performed
 
-- Reviewed current pipeline README and weather-context documentation.
-- Reviewed `weather_context.py`, `main.py`, and `update_city.py` read-only to confirm intended non-blocking enrichment/write behavior.
-- Ran read-only Supabase evidence queries only.
-- Confirmed evidence output shows latest active-city rows and coverage counts.
-- Confirmed this PR is docs-only.
+- Reviewed current PR #28 state.
+- Reviewed current `docs/weather-context-live-coverage-evidence.md` from branch `docs/story-1-4-10-weather-live-coverage-evidence`.
+- Ran read-only Supabase summary evidence query only.
+- Ran read-only Supabase latest active-city details query only.
+- Confirmed follow-up evidence output shows 9 active cities.
+- Confirmed follow-up evidence output shows 9/9 latest active-city readings with AQI.
+- Confirmed follow-up evidence output shows 9/9 latest active-city readings with `weather_provider = 'open-meteo'`.
+- Confirmed follow-up evidence output shows 9/9 latest active-city readings with complete core weather context.
+- Confirmed this PR remains docs-only.
 - Confirmed no runtime files were modified.
 - Confirmed no workflow schedule files were modified.
 - Confirmed no DDL was executed.

--- a/docs/weather-context-live-coverage-evidence.md
+++ b/docs/weather-context-live-coverage-evidence.md
@@ -1,10 +1,10 @@
 # Weather Context Live Coverage Evidence — MtyRespira
 
-Status: complete follow-up live coverage evidence  
+Status: complete RPC-aligned follow-up live coverage evidence  
 Scope: `elelier/airquality_pipeline`  
 Target DB: `monterrey-respira-db` (`xjekikweaiddfwjjaqbd`)  
 Initial review timestamp: 2026-05-26 08:20 UTC  
-Follow-up review timestamp: 2026-05-29 00:10 UTC  
+RPC-aligned follow-up review timestamp: 2026-05-29 14:45 UTC  
 Decision type: Data QA / Architecture validation / Docs
 
 ## Summary
@@ -17,11 +17,13 @@ This document records read-only live evidence for canonical Open-Meteo weather-c
 
 Initial evidence captured from latest active-city readings created around `2026-05-26 04:55..04:57 UTC` showed partial coverage: 5 of 9 latest active-city readings had canonical Open-Meteo context. Those rows were after PR #26 merged and before PR #27 merged, so they confirmed post-coordinate-fix coverage but did not validate post-PR-27 retry behavior.
 
-Follow-up evidence captured on `2026-05-29` from latest active-city readings created around `2026-05-29 00:00..00:02 UTC` confirms complete canonical Open-Meteo coverage across all active cities.
+A follow-up on `2026-05-29` originally used insertion order. Review feedback correctly noted that evidence intended to support RPC/frontend readiness must mirror the production `get_latest_air_quality_per_city` freshness order.
+
+This document now uses RPC-aligned evidence: latest rows are selected by `reading_timestamp desc`, with `created_at desc` only as a deterministic tie-breaker for evidence stability. The RPC-aligned follow-up confirms complete canonical Open-Meteo coverage across all active cities.
 
 Result summary:
 
-| Metric | Initial result | Follow-up result |
+| Metric | Initial result | RPC-aligned follow-up result |
 | --- | ---: | ---: |
 | Active cities checked | 9 | 9 |
 | Active cities with latest reading | 9 | 9 |
@@ -30,7 +32,7 @@ Result summary:
 | Latest readings with complete core weather context | 5 | 9 |
 | Active cities missing canonical weather context | 4 | 0 |
 
-Decision: **initial evidence was partial; follow-up evidence confirms complete 9/9 canonical Open-Meteo coverage.**
+Decision: **initial evidence was partial; RPC-aligned follow-up evidence confirms complete 9/9 canonical Open-Meteo coverage.**
 
 ## Scope
 
@@ -53,51 +55,49 @@ It does not change:
 - city geolocation,
 - public frontend contract.
 
-## Evidence query intent
+## Production RPC freshness contract
 
-The evidence checks the latest reading for each active city and asks:
+The production `get_latest_air_quality_per_city` migration ranks readings per city by measurement freshness:
 
-1. Does every active city have a recent latest reading?
-2. Does every latest reading still have AQI?
-3. Which latest readings include canonical Open-Meteo fields?
-4. Which cities are still missing canonical weather context?
-5. Do follow-up latest rows confirm complete post-PR-27 Open-Meteo coverage?
+```sql
+row_number() over (
+  partition by aqr.city_id
+  order by aqr.reading_timestamp desc
+) as rn
+```
 
-PR merge reference:
+Because the frontend consumes this RPC, coverage evidence must validate the same row set the public contract exposes. The evidence query therefore selects one latest row per active city using `reading_timestamp desc`; `created_at desc` is used only as a deterministic tie-breaker for the evidence query.
 
-| PR | Merge time UTC |
-| --- | --- |
-| PR #26 | 2026-05-25 20:11:50 UTC |
-| PR #27 | 2026-05-26 07:25:52 UTC |
-
-The initial rows captured below were created around `2026-05-26 04:55..04:57 UTC`, which is after PR #26 but before PR #27. Therefore the initial evidence confirmed post-coordinate-fix coverage, but not a post-PR-27 scheduled insert.
-
-The follow-up rows captured below were created around `2026-05-29 00:00..00:02 UTC`, which is after PR #27. Therefore this follow-up evidence confirms complete current canonical Open-Meteo coverage for latest active-city readings.
-
-## Read-only summary query
+## Read-only RPC-aligned summary query
 
 ```sql
 with latest as (
-  select distinct on (c.id)
-    c.id as city_id,
-    c.name as city_name,
-    c.is_active,
-    r.id as reading_id,
-    r.created_at,
-    r.reading_timestamp,
-    r.aqi_us,
-    r.main_pollutant_us,
-    r.weather_provider,
-    r.weather_temperature_c,
-    r.weather_humidity_percent,
-    r.weather_wind_speed_kmh,
-    r.weather_wind_direction_deg,
-    r.weather_wind_gust_kmh,
-    r.weather_timestamp
-  from public.cities c
-  left join public.air_quality_readings r on r.city_id = c.id
-  where c.is_active = true
-  order by c.id, r.created_at desc nulls last
+  select *
+  from (
+    select
+      c.id as city_id,
+      c.name as city_name,
+      r.id as reading_id,
+      r.created_at,
+      r.reading_timestamp,
+      r.aqi_us,
+      r.main_pollutant_us,
+      r.weather_provider,
+      r.weather_temperature_c,
+      r.weather_humidity_percent,
+      r.weather_wind_speed_kmh,
+      r.weather_wind_direction_deg,
+      r.weather_wind_gust_kmh,
+      r.weather_timestamp,
+      row_number() over (
+        partition by r.city_id
+        order by r.reading_timestamp desc, r.created_at desc
+      ) as rn
+    from public.air_quality_readings r
+    join public.cities c on r.city_id = c.id
+    where c.is_active = true
+  ) ranked
+  where rn = 1
 )
 select
   count(*) as active_cities,
@@ -111,12 +111,14 @@ select
       and weather_wind_speed_kmh is not null
       and weather_timestamp is not null
   ) as latest_readings_with_complete_core_weather,
+  max(reading_timestamp) as newest_reading_timestamp,
+  min(reading_timestamp) as oldest_latest_reading_timestamp,
   max(created_at) as newest_created_at,
   min(created_at) as oldest_latest_created_at
 from latest;
 ```
 
-Initial result:
+RPC-aligned follow-up result:
 
 ```json
 [
@@ -124,10 +126,12 @@ Initial result:
     "active_cities": 9,
     "active_cities_with_latest_reading": 9,
     "latest_readings_with_aqi": 9,
-    "latest_readings_with_open_meteo": 5,
-    "latest_readings_with_complete_core_weather": 5,
-    "newest_created_at": "2026-05-26 04:57:55.99183+00",
-    "oldest_latest_created_at": "2026-05-26 04:55:50.808115+00"
+    "latest_readings_with_open_meteo": 9,
+    "latest_readings_with_complete_core_weather": 9,
+    "newest_reading_timestamp": "2026-05-29 13:00:00+00",
+    "oldest_latest_reading_timestamp": "2026-05-29 08:00:00+00",
+    "newest_created_at": "2026-05-29 14:36:18.822865+00",
+    "oldest_latest_created_at": "2026-05-29 11:20:50.860009+00"
   }
 ]
 ```
@@ -146,70 +150,27 @@ Initial result:
 | San Pedro Garza Garcia | 2026-05-26 04:57:24 | 46 | `pm25` | `open-meteo` | complete |
 | Santa Catarina | 2026-05-26 04:55:50 | 42 | `pm25` | `open-meteo` | complete |
 
-Initial cities with complete canonical weather context:
+## Follow-up evidence — 2026-05-29, RPC-aligned
 
-- Garcia
-- General Escobedo
-- Guadalupe
-- San Pedro Garza Garcia
-- Santa Catarina
-
-Initial cities missing canonical weather context on latest reading:
-
-- Cadereyta Jimenez
-- Ciudad Benito Juárez
-- Monterrey
-- San Nicolas de los Garza
-
-## Follow-up evidence — 2026-05-29
-
-Read-only summary result:
-
-```json
-[
-  {
-    "active_cities": 9,
-    "active_cities_with_latest_reading": 9,
-    "latest_readings_with_aqi": 9,
-    "latest_readings_with_open_meteo": 9,
-    "latest_readings_with_complete_core_weather": 9,
-    "newest_created_at": "2026-05-29 00:02:41.016918+00",
-    "oldest_latest_created_at": "2026-05-29 00:00:24.009169+00"
-  }
-]
-```
-
-Follow-up coverage by city:
+Follow-up coverage by city using `reading_timestamp desc`, with `created_at desc` as tie-breaker:
 
 | City | Created at UTC | Reading timestamp UTC | AQI | Main pollutant | Weather provider | Temperature C | Humidity % | Wind km/h | Wind direction deg | Gust km/h | Weather timestamp UTC | Core weather fields |
 | --- | --- | --- | ---: | --- | --- | ---: | ---: | ---: | ---: | ---: | --- | --- |
-| Cadereyta Jimenez | 2026-05-29 00:01:14 | 2026-05-28 22:00:00 | 42 | `pm25` | `open-meteo` | 31.6 | 51 | 15.3 | 117 | 20.9 | 2026-05-29 00:00:00 | complete |
-| Ciudad Benito Juárez | 2026-05-29 00:02:09 | 2026-05-28 22:00:00 | 28 | `o3` | `open-meteo` | 31.3 | 52 | 18.2 | 120 | 22.7 | 2026-05-29 00:00:00 | complete |
-| Garcia | 2026-05-29 00:01:24 | 2026-05-28 22:00:00 | 47 | `o3` | `open-meteo` | 30.1 | 50 | 30.9 | 107 | 38.9 | 2026-05-29 00:00:00 | complete |
-| General Escobedo | 2026-05-29 00:00:24 | 2026-05-28 22:00:00 | 55 | `pm25` | `open-meteo` | 31.1 | 50 | 20.0 | 116 | 27.4 | 2026-05-29 00:00:00 | complete |
-| Guadalupe | 2026-05-29 00:02:20 | 2026-05-28 21:00:00 | 30 | `o3` | `open-meteo` | 30.8 | 52 | 18.8 | 119 | 27.0 | 2026-05-29 00:00:00 | complete |
-| Monterrey | 2026-05-29 00:02:41 | 2026-05-28 22:00:00 | 45 | `pm25` | `open-meteo` | 30.5 | 51 | 19.1 | 106 | 26.6 | 2026-05-29 00:00:00 | complete |
-| San Nicolas de los Garza | 2026-05-29 00:01:03 | 2026-05-28 22:00:00 | 58 | `pm25` | `open-meteo` | 31.0 | 51 | 18.4 | 116 | 27.4 | 2026-05-29 00:00:00 | complete |
-| San Pedro Garza Garcia | 2026-05-29 00:02:30 | 2026-05-28 22:00:00 | 42 | `o3` | `open-meteo` | 30.2 | 51 | 21.1 | 99 | 29.5 | 2026-05-29 00:00:00 | complete |
-| Santa Catarina | 2026-05-29 00:00:52 | 2026-05-28 22:00:00 | 34 | `pm25` | `open-meteo` | 29.8 | 52 | 21.3 | 95 | 32.0 | 2026-05-29 00:00:00 | complete |
+| Cadereyta Jimenez | 2026-05-29 14:36:43 | 2026-05-29 12:00:00 | 21 | `pm25` | `open-meteo` | 25.4 | 81 | 4.9 | 107 | 10.8 | 2026-05-29 14:30:00 | complete |
+| Ciudad Benito Juárez | 2026-05-29 14:35:02 | 2026-05-29 12:00:00 | 21 | `pm10` | `open-meteo` | 25.2 | 84 | 4.7 | 113 | 11.2 | 2026-05-29 14:30:00 | complete |
+| Garcia | 2026-05-29 14:34:52 | 2026-05-29 12:00:00 | 52 | `pm25` | `open-meteo` | 25.0 | 76 | 4.1 | 135 | 4.3 | 2026-05-29 14:30:00 | complete |
+| General Escobedo | 2026-05-29 14:35:57 | 2026-05-29 12:00:00 | 56 | `pm25` | `open-meteo` | 24.3 | 86 | 4.2 | 70 | 9.0 | 2026-05-29 14:30:00 | complete |
+| Guadalupe | 2026-05-29 14:35:12 | 2026-05-29 12:00:00 | 22 | `pm10` | `open-meteo` | 25.4 | 82 | 4.7 | 81 | 10.8 | 2026-05-29 14:30:00 | complete |
+| Monterrey | 2026-05-29 14:35:33 | 2026-05-29 12:00:00 | 49 | `pm25` | `open-meteo` | 24.6 | 83 | 2.9 | 30 | 6.5 | 2026-05-29 14:30:00 | complete |
+| San Nicolas de los Garza | 2026-05-29 14:36:18 | 2026-05-29 13:00:00 | 54 | `pm25` | `open-meteo` | 24.7 | 84 | 2.7 | 23 | 8.6 | 2026-05-29 14:30:00 | complete |
+| San Pedro Garza Garcia | 2026-05-29 14:35:23 | 2026-05-29 12:00:00 | 16 | `o3` | `open-meteo` | 25.0 | 78 | 2.5 | 82 | 3.6 | 2026-05-29 14:30:00 | complete |
+| Santa Catarina | 2026-05-29 14:36:08 | 2026-05-29 13:00:00 | 42 | `pm25` | `open-meteo` | 25.3 | 80 | 7.6 | 177 | 7.6 | 2026-05-29 14:30:00 | complete |
 
-Follow-up cities with complete canonical weather context:
-
-- Cadereyta Jimenez
-- Ciudad Benito Juárez
-- Garcia
-- General Escobedo
-- Guadalupe
-- Monterrey
-- San Nicolas de los Garza
-- San Pedro Garza Garcia
-- Santa Catarina
-
-Follow-up cities missing canonical weather context on latest reading: **none**.
+RPC-aligned follow-up cities missing canonical weather context on latest reading: **none**.
 
 ## AQI safety check
 
-All 9 active cities have a latest reading with non-null AQI in both the initial and follow-up evidence sets.
+All 9 active cities have a latest reading with non-null AQI in both the initial and RPC-aligned follow-up evidence sets.
 
 This supports the intended behavior that weather context remains separate from AQI and does not block successful AQI inserts.
 
@@ -219,7 +180,7 @@ No AQI rewrite or pollutant rewrite was performed by this evidence story.
 
 Initial evidence showed canonical Open-Meteo weather context on 5 of 9 latest active-city readings.
 
-Follow-up evidence shows canonical Open-Meteo weather context on 9 of 9 latest active-city readings, including these core canonical fields:
+RPC-aligned follow-up evidence shows canonical Open-Meteo weather context on 9 of 9 latest active-city readings, including these core canonical fields:
 
 - `weather_temperature_c`
 - `weather_humidity_percent`
@@ -228,11 +189,17 @@ Follow-up evidence shows canonical Open-Meteo weather context on 9 of 9 latest a
 
 ## Decision
 
-**Initial evidence was partial; follow-up evidence confirms complete 9/9 canonical Open-Meteo coverage.**
+**Initial evidence was partial; RPC-aligned follow-up evidence confirms complete 9/9 canonical Open-Meteo coverage.**
 
-This evidence supports treating the missing-city coverage gap observed on `2026-05-26` as superseded by the `2026-05-29` read-only follow-up snapshot.
+This evidence supports treating the missing-city coverage gap observed on `2026-05-26` as superseded by the `2026-05-29` read-only RPC-aligned follow-up snapshot.
 
 This documentation update does not authorize frontend adoption, backfill, RPC changes, workflow changes, or runtime changes by itself. Those should remain separate stories with their own validation gates.
+
+## Review comment resolution
+
+Resolved P2 `Match the evidence query to the RPC freshness order` by changing the evidence selection from `created_at desc` to an RPC-aligned `reading_timestamp desc` order, with `created_at desc` retained only as a deterministic tie-breaker for evidence reproducibility.
+
+The recaptured read-only evidence still confirms 9/9 canonical Open-Meteo coverage for the rows the frontend/RPC contract would expose.
 
 ## Recommended next step
 
@@ -276,12 +243,14 @@ No service-role guidance was added for frontend/app usage.
 
 - Reviewed current PR #28 state.
 - Reviewed current `docs/weather-context-live-coverage-evidence.md` from branch `docs/story-1-4-10-weather-live-coverage-evidence`.
-- Ran read-only Supabase summary evidence query only.
-- Ran read-only Supabase latest active-city details query only.
+- Reviewed the migration defining `get_latest_air_quality_per_city` and confirmed the RPC freshness order is `reading_timestamp desc`.
+- Updated the evidence query to mirror the RPC freshness order.
+- Ran read-only Supabase RPC-aligned summary evidence query only.
+- Ran read-only Supabase RPC-aligned latest active-city details query only.
 - Confirmed follow-up evidence output shows 9 active cities.
-- Confirmed follow-up evidence output shows 9/9 latest active-city readings with AQI.
-- Confirmed follow-up evidence output shows 9/9 latest active-city readings with `weather_provider = 'open-meteo'`.
-- Confirmed follow-up evidence output shows 9/9 latest active-city readings with complete core weather context.
+- Confirmed follow-up evidence output shows 9/9 RPC-selected latest active-city readings with AQI.
+- Confirmed follow-up evidence output shows 9/9 RPC-selected latest active-city readings with `weather_provider = 'open-meteo'`.
+- Confirmed follow-up evidence output shows 9/9 RPC-selected latest active-city readings with complete core weather context.
 - Confirmed this PR remains docs-only.
 - Confirmed no runtime files were modified.
 - Confirmed no workflow schedule files were modified.

--- a/docs/weather-context-live-coverage-evidence.md
+++ b/docs/weather-context-live-coverage-evidence.md
@@ -1,0 +1,271 @@
+# Weather Context Live Coverage Evidence — MtyRespira
+
+Status: partial live coverage evidence  
+Scope: `elelier/airquality_pipeline`  
+Target DB: `monterrey-respira-db` (`xjekikweaiddfwjjaqbd`)  
+Review timestamp: 2026-05-26 08:20 UTC  
+Decision type: Data QA / Architecture validation / Docs
+
+## Summary
+
+This document records read-only live evidence for canonical Open-Meteo weather-context coverage after:
+
+- PR #23: `feat: add Open-Meteo weather context write path`
+- PR #26: `fix: use canonical city coordinates for weather context`
+- PR #27: `fix: improve retry handling`
+
+The latest active-city readings are post-merge and confirm that AQI inserts continue. Weather context coverage is real but still partial.
+
+Result summary:
+
+| Metric | Result |
+| --- | ---: |
+| Active cities checked | 9 |
+| Active cities with latest reading | 9 |
+| Latest readings with AQI | 9 |
+| Latest readings with `weather_provider = 'open-meteo'` | 5 |
+| Latest readings with complete core weather context | 5 |
+| Active cities missing canonical weather context | 4 |
+
+Decision: **partial coverage — investigate missing weather context by city before frontend adoption or backfill.**
+
+## Scope
+
+This story is evidence-only.
+
+It does not change:
+
+- Supabase schema,
+- data rows,
+- backfill state,
+- runtime pipeline code,
+- WAQI/AQICN provider behavior,
+- RPCs,
+- frontend code,
+- workflow schedule,
+- AQI values,
+- `main_pollutant_us`,
+- historical AQI,
+- city identity,
+- city geolocation,
+- public frontend contract.
+
+## Evidence query intent
+
+The evidence checks the latest reading for each active city and asks:
+
+1. Does every active city have a recent latest reading?
+2. Does every latest reading still have AQI?
+3. Which latest readings include canonical Open-Meteo fields?
+4. Which cities are still missing canonical weather context?
+5. Are the latest rows newer than PR #26 and PR #27 merge times?
+
+PR merge reference:
+
+| PR | Merge time UTC |
+| --- | --- |
+| PR #26 | 2026-05-25 20:11:50 UTC |
+| PR #27 | 2026-05-26 07:25:52 UTC |
+
+The latest rows captured below were created around `2026-05-26 04:55..04:57 UTC`, which is after PR #26 but before PR #27. Therefore this evidence confirms post-coordinate-fix coverage, but not yet a post-PR-27 scheduled insert. The retry fix should still be verified on a later post-PR-27 run if retry behavior is specifically under review.
+
+## Read-only summary query
+
+```sql
+with latest as (
+  select distinct on (c.id)
+    c.id as city_id,
+    c.name as city_name,
+    c.is_active,
+    r.id as reading_id,
+    r.created_at,
+    r.reading_timestamp,
+    r.aqi_us,
+    r.main_pollutant_us,
+    r.weather_provider,
+    r.weather_temperature_c,
+    r.weather_humidity_percent,
+    r.weather_wind_speed_kmh,
+    r.weather_wind_direction_deg,
+    r.weather_wind_gust_kmh,
+    r.weather_timestamp
+  from public.cities c
+  left join public.air_quality_readings r on r.city_id = c.id
+  where c.is_active = true
+  order by c.id, r.created_at desc nulls last
+)
+select
+  count(*) as active_cities,
+  count(*) filter (where reading_id is not null) as active_cities_with_latest_reading,
+  count(*) filter (where aqi_us is not null) as latest_readings_with_aqi,
+  count(*) filter (where weather_provider = 'open-meteo') as latest_readings_with_open_meteo,
+  count(*) filter (
+    where weather_provider = 'open-meteo'
+      and weather_temperature_c is not null
+      and weather_humidity_percent is not null
+      and weather_wind_speed_kmh is not null
+      and weather_timestamp is not null
+  ) as latest_readings_with_complete_core_weather,
+  max(created_at) as newest_created_at,
+  min(created_at) as oldest_latest_created_at
+from latest;
+```
+
+Result:
+
+```json
+[
+  {
+    "active_cities": 9,
+    "active_cities_with_latest_reading": 9,
+    "latest_readings_with_aqi": 9,
+    "latest_readings_with_open_meteo": 5,
+    "latest_readings_with_complete_core_weather": 5,
+    "newest_created_at": "2026-05-26 04:57:55.99183+00",
+    "oldest_latest_created_at": "2026-05-26 04:55:50.808115+00"
+  }
+]
+```
+
+## Coverage by city
+
+| City | Created at UTC | AQI | Main pollutant | Weather provider | Core weather fields |
+| --- | --- | ---: | --- | --- | --- |
+| Cadereyta Jimenez | 2026-05-26 04:56:32 | 55 | `pm25` | null | missing |
+| Ciudad Benito Juárez | 2026-05-26 04:57:03 | 55 | `pm25` | null | missing |
+| Garcia | 2026-05-26 04:56:42 | 33 | `pm25` | `open-meteo` | complete |
+| General Escobedo | 2026-05-26 04:57:55 | 46 | `pm25` | `open-meteo` | complete |
+| Guadalupe | 2026-05-26 04:57:13 | 31 | `o3` | `open-meteo` | complete |
+| Monterrey | 2026-05-26 04:57:45 | 34 | `pm25` | null | missing |
+| San Nicolas de los Garza | 2026-05-26 04:56:11 | 58 | `pm25` | null | missing |
+| San Pedro Garza Garcia | 2026-05-26 04:57:24 | 46 | `pm25` | `open-meteo` | complete |
+| Santa Catarina | 2026-05-26 04:55:50 | 42 | `pm25` | `open-meteo` | complete |
+
+Cities with complete canonical weather context:
+
+- Garcia
+- General Escobedo
+- Guadalupe
+- San Pedro Garza Garcia
+- Santa Catarina
+
+Cities still missing canonical weather context on latest reading:
+
+- Cadereyta Jimenez
+- Ciudad Benito Juárez
+- Monterrey
+- San Nicolas de los Garza
+
+## AQI safety check
+
+All 9 active cities have a latest reading with non-null AQI.
+
+This supports the intended behavior that weather context remains separate from AQI and does not block successful AQI inserts.
+
+Observed latest AQI values remain present across both groups:
+
+- Cities with Open-Meteo context: AQI values present.
+- Cities without Open-Meteo context: AQI values present.
+
+No AQI rewrite or pollutant rewrite was performed by this evidence story.
+
+## Weather context completeness
+
+For the 5 latest readings with `weather_provider = 'open-meteo'`, the core canonical fields were present:
+
+- `weather_temperature_c`
+- `weather_humidity_percent`
+- `weather_wind_speed_kmh`
+- `weather_timestamp`
+
+Observed complete-weather examples:
+
+| City | Temperature C | Humidity % | Wind km/h | Wind direction deg | Gust km/h | Weather timestamp UTC |
+| --- | ---: | ---: | ---: | ---: | ---: | --- |
+| Garcia | 24.5 | 73 | 29.2 | 86 | 48.6 | 2026-05-26 04:45:00 |
+| General Escobedo | 25.2 | 76 | 17.9 | 115 | 33.1 | 2026-05-26 04:45:00 |
+| Guadalupe | 25.0 | 76 | 17.6 | 125 | 33.5 | 2026-05-26 04:45:00 |
+| San Pedro Garza Garcia | 24.9 | 70 | 19.2 | 67 | 29.9 | 2026-05-26 04:45:00 |
+| Santa Catarina | 24.2 | 74 | 24.4 | 68 | 36.0 | 2026-05-26 04:45:00 |
+
+## Gaps / cities pending
+
+Coverage is not yet sufficient for frontend adoption because 4 of 9 active cities still have null canonical weather context on latest readings.
+
+Pending investigation should focus on why these cities inserted AQI successfully but did not persist weather context:
+
+- Cadereyta Jimenez
+- Ciudad Benito Juárez
+- Monterrey
+- San Nicolas de los Garza
+
+Likely investigation areas for a future runtime/debug story:
+
+- Confirm whether canonical `cities.latitude` and `cities.longitude` are present and parseable for each missing city.
+- Inspect pipeline logs for `[Weather]` errors on these cities.
+- Confirm whether Open-Meteo returned non-retryable client errors, retryable server errors, invalid payload, validation failure, or missing coordinates.
+- Confirm whether city coordinate updates from WAQI overwrite canonical city coordinates before weather enrichment or after insert.
+- Capture a post-PR-27 run to verify the retry handling fix under current production behavior.
+
+## Decision
+
+**Partial coverage. Do not proceed directly to frontend adoption or weather backfill.**
+
+Open-Meteo write path is working for some cities and AQI remains safe, but coverage is incomplete across active municipalities.
+
+## Recommended next step
+
+Create a small runtime/Data QA investigation story:
+
+```text
+Story 1.4.11 — Weather Context Missing City Diagnostics
+```
+
+Suggested scope:
+
+- Read-only inspect active city coordinates for missing cities.
+- Review latest workflow logs for weather error types, without exposing secrets.
+- Add non-sensitive structured logging if current logs do not identify weather failure reason per city.
+- Add tests if a deterministic bug is found.
+- No backfill, no frontend, no DDL, no RPC changes until coverage is understood.
+
+If a post-PR-27 scheduled run later reaches 9/9 Open-Meteo coverage, this document can be superseded by a new coverage evidence note and the next step may shift to RPC live apply verification or frontend adoption.
+
+## No-write guarantees
+
+This story did not perform:
+
+- Supabase DDL,
+- Supabase data mutation,
+- backfill,
+- runtime code changes,
+- workflow schedule changes,
+- RPC changes,
+- frontend changes,
+- AQI provider changes,
+- secret exposure.
+
+No secret assignment patterns were added for WAQI, AirVisual, or Supabase service-role credentials.
+
+No service-role guidance was added for frontend/app usage.
+
+## Validation performed
+
+- Reviewed current pipeline README and weather-context documentation.
+- Reviewed `weather_context.py`, `main.py`, and `update_city.py` read-only to confirm intended non-blocking enrichment/write behavior.
+- Ran read-only Supabase evidence queries only.
+- Confirmed evidence output shows latest active-city rows and coverage counts.
+- Confirmed this PR is docs-only.
+- Confirmed no runtime files were modified.
+- Confirmed no workflow schedule files were modified.
+- Confirmed no DDL was executed.
+- Confirmed no backfill was performed.
+- Confirmed AQI, `main_pollutant_us`, historical AQI, city identity, geolocation, and public frontend contract were not changed.
+
+## Rollback
+
+Revert this documentation PR.
+
+No database rollback is required because this story is read-only evidence documentation.
+
+No runtime, Cloudflare, workflow, RPC, frontend, AQI, or provider rollback is required.

--- a/docs/weather-context-live-coverage-evidence.md
+++ b/docs/weather-context-live-coverage-evidence.md
@@ -12,9 +12,8 @@ This document records read-only live evidence for canonical Open-Meteo weather-c
 
 - PR #23: `feat: add Open-Meteo weather context write path`
 - PR #26: `fix: use canonical city coordinates for weather context`
-- PR #27: `fix: improve retry handling`
 
-The latest active-city readings are post-merge and confirm that AQI inserts continue. Weather context coverage is real but still partial.
+The captured latest active-city readings were created around `2026-05-26 04:55..04:57 UTC`, which is after PR #26 merged and before PR #27 (`fix: improve retry handling`) merged. This evidence confirms post-coordinate-fix coverage and AQI insert safety, but it does not validate post-PR-27 retry behavior. Weather context coverage is real but still partial.
 
 Result summary:
 
@@ -58,7 +57,7 @@ The evidence checks the latest reading for each active city and asks:
 2. Does every latest reading still have AQI?
 3. Which latest readings include canonical Open-Meteo fields?
 4. Which cities are still missing canonical weather context?
-5. Are the latest rows newer than PR #26 and PR #27 merge times?
+5. Do the latest rows fall after PR #26 and before PR #27, making this a coordinate-fix coverage check rather than a retry-fix validation check?
 
 PR merge reference:
 


### PR DESCRIPTION
## Summary

Adds read-only live coverage evidence for canonical Open-Meteo weather context after the coordinate and retry fixes.

This PR now includes the original 2026-05-26 partial snapshot plus a 2026-05-29 direct RPC-output follow-up snapshot.

## Evidence captured

Target DB: `monterrey-respira-db` / `xjekikweaiddfwjjaqbd`.

### Initial evidence — 2026-05-26

- Latest active-city readings checked: 9.
- Latest active-city readings with AQI: 9.
- Latest active-city readings with `weather_provider = 'open-meteo'`: 5.
- Latest active-city readings with complete core weather context: 5.
- Active cities still missing canonical weather context: 4.

Note: the initial captured latest rows were post-PR #26 but before PR #27 merge time, so they confirmed post-coordinate-fix coverage but not post-PR-27 retry behavior.

### Direct RPC-output follow-up evidence — 2026-05-29

The P1 review correctly noted that a documentary latest-row query with extra tie-breakers can diverge from the RPC because `get_latest_air_quality_per_city` orders only by `reading_timestamp desc`.

The follow-up evidence now validates the actual public RPC output directly:

```sql
select *
from public.get_latest_air_quality_per_city();
```

Results:

- Active cities checked from `public.cities`: 9.
- RPC rows returned: 9.
- RPC rows with AQI: 9.
- RPC rows with `weather_provider = 'open-meteo'`: 9.
- RPC rows with complete core weather context: 9.
- Active/RPC row count mismatch: 0.

## Decision

Initial evidence was partial; direct RPC-output follow-up evidence confirms complete 9/9 canonical Open-Meteo coverage.

This documentation update does not authorize frontend adoption, backfill, RPC changes, workflow changes, or runtime changes by itself. Those should remain separate stories with their own validation gates.

## Review comments resolved

- Resolved P1 `Preserve the RPC's actual row ordering` by removing documentary reliance on `created_at desc` / `NULLS LAST` tie-breakers and validating `public.get_latest_air_quality_per_city()` output directly.
- Resolved P2 `Match the evidence query to the RPC freshness order` by switching evidence to the actual RPC output.
- Resolved P2 `Reconcile the follow-up aggregate with the detail rows` by regenerating aggregate and detail rows from direct RPC output.
- Resolved P2 `Count active cities from the cities table` by counting active cities from `public.cities` and comparing that count with RPC rows returned.

## No-write guarantees

- No Supabase DDL.
- No Supabase data mutation.
- No backfill.
- No runtime code changes.
- No workflow schedule changes.
- No RPC changes.
- No frontend changes.
- No AQI provider changes.
- No AQI, `main_pollutant_us`, historical AQI, city identity, geolocation, or public contract changes.
- No secrets exposed.
- No service-role guidance added for frontend/app usage.

## Validation performed

- Validated GitHub connector with `get_repo elelier/airquality_pipeline`.
- Reviewed current PR #28 and P1 review thread.
- Reviewed the migration defining `get_latest_air_quality_per_city` and confirmed the production RPC freshness order is `reading_timestamp desc` only.
- Ran read-only active-city count query.
- Ran read-only direct RPC aggregate evidence query.
- Ran read-only direct RPC detail evidence query.
- Ran read-only recent duplicate timestamp diagnostic.
- Confirmed 9 active cities.
- Confirmed 9 RPC rows.
- Confirmed 9/9 RPC rows with AQI.
- Confirmed 9/9 RPC rows with `weather_provider = 'open-meteo'`.
- Confirmed 9/9 RPC rows with complete core weather context.
- Updated only `docs/weather-context-live-coverage-evidence.md`.
- Confirmed docs-only diff.
- Confirmed no runtime files were modified.
- Confirmed no workflow schedule files were modified.
- Confirmed no DDL was executed.
- Confirmed no backfill was performed.

## Area touched

Pipeline documentation only.

## Risks / pending items

- Complete latest-row coverage is now documented against actual RPC output, but UI/RPC adoption still needs its own scoped validation story.
- Historical weather backfill remains intentionally out of scope.

## Rollback

Revert this docs-only PR. No DB, runtime, Cloudflare, workflow, RPC, frontend, AQI, or provider rollback is required.